### PR TITLE
ARCH-1044 - Filter the tags by the prefix +semver:breaking

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v1.0.0
+        uses: im-open/git-version-lite@v2.0.0
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The action has a `create-ref` flag and when set to true it uses the GitHub rest 
 | Parameter                      | Is Required                                            | Default | Description                                                                                                                                                                                                                                                                                                |
 | ------------------------------ | ------------------------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tag-prefix`                   | false                                                  | `v`     | By default the action strips the prefixes off, but any value provided here will be prepended to the next calculated version.<br/><br/>GitHub indicates it is common practice to prefix your version names with the letter `v` (which is the default).  If you do not want a prefix use `tag-prefix: none`. |
+| `fallback-to-no-prefix-search` | false                                                  | `true`  | Flag indicating whether it should fallback to a prefix-less search if no tags are found with the current prefix.  Helpful when starting to use prefixes with tags.  Accepted values: true\|false.                                                                                                          |
 | `calculate-prerelease-version` | false                                                  | `false` | Flag indicating whether to calculate a pre-release version rather than a release version.  Accepts: `true\|false`.                                                                                                                                                                                         |
 | `branch-name`                  | Required when<br/>`calculate-prerelease-version: true` | N/A     | The name of the branch the next pre-release version is being generated for. Required when calculating the pre-release version.                                                                                                                                                                             |
 | `create-ref`                   | false                                                  | `false` | Flag indicating whether the action should [create a ref] (a release and tag) on the repository.    Accepted values: `true\|false`.                                                                                                                                                                         |
@@ -48,10 +49,10 @@ The action has a `create-ref` flag and when set to true it uses the GitHub rest 
 | `default-release-type`         | false                                                  | `major` | The default release type that should be used when no tags are detected.  Defaults to major.  Accepted values: `major\|minor\|patch`.                                                                                                                                                                       |
 
 ## Outputs
-| Output              | Description                                       |
-| ------------------- | ------------------------------------------------- |
-| `env`.`VERSION`     | The calculated Version as an environment variable |
-| `outputs`.`VERSION` | The calculated Version as an output               |
+| Output                   | Description                                       |
+| ------------------------ | ------------------------------------------------- |
+| `env`.`NEXT_VERSION`     | The calculated Version as an environment variable |
+| `outputs`.`NEXT_VERSION` | The calculated Version as an output               |
 
 ## Usage Examples
 
@@ -64,7 +65,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     outputs:
-      VERSION: ${{ steps.get-version.outputs.VERSION }}
+      NEXT_VERSION: ${{ steps.get-version.outputs.NEXT_VERSION }}
 
     steps:
       - uses: actions/checkout@v2
@@ -77,11 +78,12 @@ jobs:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request
           tag-prefix: v                             # Prepend a v to any calculated release/pre-release version
+          fallback-to-no-prefix-search: true        # Set to true can be helpful when starting to add tag prefixes
           default-release-type: major               # If no tags are found, default to doing a major increment
           create-ref: true                          # Will create a release/tag on the repo
           github-token: ${{ secrets.GITHUB_TOKEN }} # Required when creating a ref
       
-      - run: echo "The next version is ${{ env.VERSION }}"
+      - run: echo "The next version is ${{ env.NEXT_VERSION }}"
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'JavaScript Action Template'
+name: 'git-version-lite'
 
-description: 'Add description here'
+description: 'An action to calculate the next tag for the repository based on commit messages.'
 
 inputs:
   calculate-prerelease-version:
@@ -14,6 +14,10 @@ inputs:
     description: 'By default the action strips the prefixes off, but any value provided here will be prepended to the next calculated version.'
     required: true
     default: 'v'
+  fallback-to-no-prefix-search:
+    description: 'Flag indicating whether it should fallback to a prefix-less search if no tags are found with the current prefix.  Helpful when starting to use prefixes with tags.  Accepted values: true|false.'
+    required: true
+    default: 'true'
   default-release-type:
     description: 'The default release type that should be used when no tags are detected.  Defaults to major.  Accepted values: major|minor|patch'
     required: true
@@ -27,7 +31,7 @@ inputs:
     required: false
 
 outputs:
-  VERSION:
+  NEXT_VERSION:
     description: 'The calculated version'
 
 runs:

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ const calculatePrereleaseVersion = core.getInput('calculate-prerelease-version')
 const branchName = core.getInput('branch-name');
 const defaultReleaseType = core.getInput('default-release-type').toLowerCase();
 const createRef = core.getInput('create-ref') === 'true';
+const fallbackToNoPrefixSearch = core.getInput('fallback-to-no-prefix-search') === 'true';
 const token = core.getInput('github-token');
 let tagPrefix = core.getInput('tag-prefix');
 
@@ -63,18 +64,23 @@ async function run() {
 
       //This regex will strip out anything that's not a-z, 0-9 or the - character
       const prereleaseLabel = branchName.replace('refs/heads/', '').replace(/[^a-zA-Z0-9-]/g, '-');
-      versionToBuild = nextPrereleaseVersion(prereleaseLabel, defaultReleaseType, tagPrefix);
+      versionToBuild = nextPrereleaseVersion(
+        prereleaseLabel,
+        defaultReleaseType,
+        tagPrefix,
+        fallbackToNoPrefixSearch
+      );
     } else {
       core.info(`Calculating a release version...`);
-      versionToBuild = nextReleaseVersion(defaultReleaseType, tagPrefix);
+      versionToBuild = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
     }
 
     if (createRef) {
       await createRefOnGitHub(versionToBuild);
     }
 
-    core.setOutput('VERSION', versionToBuild);
-    core.exportVariable('VERSION', versionToBuild);
+    core.setOutput('NEXT_VERSION', versionToBuild);
+    core.exportVariable('NEXT_VERSION', versionToBuild);
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';
     core.setFailed(`An error occurred calculating the next ${versionTxt} version: ${error}`);

--- a/src/version.js
+++ b/src/version.js
@@ -22,9 +22,9 @@ const commitPatterns = {
  * Returns an object describing the commit of the prior release by looking for the most recent tag that is a "stable" semver
  * @returns {{abbreviatedCommitHash: string, authorDate: Date, committerDate: Date, semver: string}}
  */
-function getPriorReleaseCommit() {
+function getPriorReleaseCommit(tagPrefix, fallbackToNoPrefixSearch) {
   // get all the tags in the repository that represent semver release versions, sorted with the highest release version first.
-  let tags = git.listTags();
+  let tags = git.listTags(tagPrefix, fallbackToNoPrefixSearch);
   if (!tags || tags.length === 0) {
     return null;
   }
@@ -118,11 +118,11 @@ function dateToPreReleaseComponent(input) {
  * @param tagPrefix {string} The value to pre-pend to the calculated release
  * @returns {string} a SemVer release version based on the Git history since the last tagged release
  */
-function nextReleaseVersion(defaultReleaseType, tagPrefix) {
+function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
   try {
     // start from the most-recent release version
-    baseCommit = getPriorReleaseCommit();
+    baseCommit = getPriorReleaseCommit(tagPrefix, fallbackToNoPrefixSearch);
   } catch (error) {
     core.info(`An error occurred retrieving the tags for the repository: ${error}`);
   }
@@ -154,11 +154,11 @@ function nextReleaseVersion(defaultReleaseType, tagPrefix) {
  * @param tagPrefix {string} The value to pre-pend to the calculated release
  * @returns {string} a SemVer pre-release version based on the Git history since the last tagged release
  */
-function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix) {
+function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
   try {
     // start from the most-recent release version
-    baseCommit = getPriorReleaseCommit();
+    baseCommit = getPriorReleaseCommit(tagPrefix, fallbackToNoPrefixSearch);
   } catch (error) {
     core.info(`An error occurred retrieving the tags for the repository: ${error}`);
   }


### PR DESCRIPTION
Tested here: https://github.com/bc-swat/actions-testing/runs/3747385261?check_suite_focus=true

The output was changed from VERSION => NEXT_VERSION so it doesn't add an ENV variable to other things that read it like dotnet build or npm commands.