### PR TITLE
Trim tags

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6024,7 +6024,7 @@ var require_git_commands = __commonJS({
           core2.info(`The following tags exist on the repository:
 ${tags}
 `);
-          return tags.split('\n');
+          return tags.split('\n').map(t => t.trim());
         } catch (error) {
           core2.setFailed(`An error occurred listing the tags for the repository: ${error}`);
         }

--- a/src/git-commands.js
+++ b/src/git-commands.js
@@ -46,7 +46,7 @@ module.exports = {
       }
 
       core.info(`The following tags exist on the repository:\n${tags}\n`);
-      return tags.split('\n');
+      return tags.split('\n').map(t => t.trim());
     } catch (error) {
       core.setFailed(`An error occurred listing the tags for the repository: ${error}`);
     }


### PR DESCRIPTION
We are still having an issue with calculating versions using prefixes.  My only guess is that the tag has leading whitespace? For some reason it is always getting the tag with `db-1.0.0` but not the newer `db-1.0.1`.  Running the logic locally, it does fail if there is a leading space.

https://github.com/im-client/data-exchange/runs/4155549110?check_suite_focus=true
https://github.com/im-client/airflow/runs/4158791241?check_suite_focus=true