### PR TITLE
ARCH-1213 - Include the tag without the prefix as an output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,12 @@ The action has a `create-ref` flag and when set to true it uses the GitHub rest 
 | `default-release-type`         | false                                                  | `major` | The default release type that should be used when no tags are detected.  Defaults to major.  Accepted values: `major\|minor\|patch`.                                                                                                                                                                       |
 
 ## Outputs
-| Output                   | Description                                       |
-| ------------------------ | ------------------------------------------------- |
-| `env`.`NEXT_VERSION`     | The calculated Version as an environment variable |
-| `outputs`.`NEXT_VERSION` | The calculated Version as an output               |
+| Output                             | Description                                                              |
+| ---------------------------------- | ------------------------------------------------------------------------ |
+| `env`.`NEXT_VERSION`               | The calculated version as an environment variable                        |
+| `env`.`NEXT_VERSION_NO_PREFIX`     | The calculated version as an environment variable without the tag prefix |
+| `outputs`.`NEXT_VERSION`           | The calculated version as an output                                      |
+| `outputs`.`NEXT_VERSION_NO_PREFIX` | The calculated version as an output without the tag prefix               |
 
 ## Usage Examples
 
@@ -88,7 +90,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2.0.8
+        uses: im-open/git-version-lite@v2.0.9
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request
@@ -98,7 +100,9 @@ jobs:
           create-ref: true                          # Will create a release/tag on the repo
           github-token: ${{ secrets.GITHUB_TOKEN }} # Required when creating a ref
       
-      - run: echo "The next version is ${{ env.NEXT_VERSION }}"
+      - run: |
+          echo "The next version is ${{ env.NEXT_VERSION }}"
+          echo "The next version without the prefix is ${{ env.NEXT_VERSION_NO_PREFIX }}"
 
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,9 @@ inputs:
 
 outputs:
   NEXT_VERSION:
-    description: 'The calculated version'
+    description: 'The calculated next version'
+  NEXT_VERSION_NO_PREFIX:
+    description: 'The calculated next version without the tag prefix.'
 
 runs:
   using: 'node12'

--- a/dist/index.js
+++ b/dist/index.js
@@ -18773,6 +18773,10 @@ async function run() {
     }
     core.setOutput('NEXT_VERSION', versionToBuild);
     core.exportVariable('NEXT_VERSION', versionToBuild);
+    let versionToBuildNoPrefix =
+      tagPrefix.length > 0 ? versionToBuild.substring(tagPrefix.length) : versionToBuild;
+    core.setOutput('NEXT_VERSION_NO_PREFIX', versionToBuildNoPrefix);
+    core.exportVariable('NEXT_VERSION_NO_PREFIX', versionToBuildNoPrefix);
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';
     core.setFailed(`An error occurred calculating the next ${versionTxt} version: ${error}`);

--- a/src/main.js
+++ b/src/main.js
@@ -81,6 +81,11 @@ async function run() {
 
     core.setOutput('NEXT_VERSION', versionToBuild);
     core.exportVariable('NEXT_VERSION', versionToBuild);
+
+    let versionToBuildNoPrefix =
+      tagPrefix.length > 0 ? versionToBuild.substring(tagPrefix.length) : versionToBuild;
+    core.setOutput('NEXT_VERSION_NO_PREFIX', versionToBuildNoPrefix);
+    core.exportVariable('NEXT_VERSION_NO_PREFIX', versionToBuildNoPrefix);
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';
     core.setFailed(`An error occurred calculating the next ${versionTxt} version: ${error}`);


### PR DESCRIPTION
# Summary of PR changes

- Include the next version without the tag prefix as an output.  When a prefix is included it isn't always compatible with things like a dotnet build so users have to calculate the value themselves from the next version.

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
