### PR TITLE
ARCH-1615 - Actions maintenance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,10 @@ on:
   # trigger because checkout, build, format and checking for changes do not need elevated
   # permissions to the repository.  The reduced permissions for public forks is adequate.
   pull_request:
-    paths-ignore:
-      - '**.md'
+    # Don't include any specific paths here so we always get a build that produces a status
+    # check that our Branch Protection Rules can use.  Having a status check also allows us
+    # to require that branches be up to date before they are merged.
+
 jobs:
   build:
     runs-on: ${{ matrix.operating-system }}
@@ -18,10 +20,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Node.js 14
+      - name: Setup Node.js 16
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Build
         run: npm run build
       - name: Format

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -15,6 +15,12 @@ on:
   #      reviewed, approved by a CODEOWNER and merged
   pull_request_target:
     types: [closed]
+    paths:
+      - 'dist/**'
+      - 'src/**'
+      - 'action.yml'
+      - 'package.json'
+      - 'package-lock.json'
 
 jobs:
   increment-version:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ jobs:
       NEXT_VERSION: ${{ steps.get-version.outputs.NEXT_VERSION }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0                        # Includes all history for all branches and tags
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2.1.1
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/dist/index.js
+++ b/dist/index.js
@@ -142,69 +142,6 @@ var require_command = __commonJS({
   }
 });
 
-// node_modules/@actions/core/lib/file-command.js
-var require_file_command = __commonJS({
-  'node_modules/@actions/core/lib/file-command.js'(exports2) {
-    'use strict';
-    var __createBinding =
-      (exports2 && exports2.__createBinding) ||
-      (Object.create
-        ? function (o, m, k, k2) {
-            if (k2 === void 0) k2 = k;
-            Object.defineProperty(o, k2, {
-              enumerable: true,
-              get: function () {
-                return m[k];
-              }
-            });
-          }
-        : function (o, m, k, k2) {
-            if (k2 === void 0) k2 = k;
-            o[k2] = m[k];
-          });
-    var __setModuleDefault =
-      (exports2 && exports2.__setModuleDefault) ||
-      (Object.create
-        ? function (o, v) {
-            Object.defineProperty(o, 'default', { enumerable: true, value: v });
-          }
-        : function (o, v) {
-            o['default'] = v;
-          });
-    var __importStar =
-      (exports2 && exports2.__importStar) ||
-      function (mod) {
-        if (mod && mod.__esModule) return mod;
-        var result = {};
-        if (mod != null) {
-          for (var k in mod)
-            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
-              __createBinding(result, mod, k);
-        }
-        __setModuleDefault(result, mod);
-        return result;
-      };
-    Object.defineProperty(exports2, '__esModule', { value: true });
-    exports2.issueCommand = void 0;
-    var fs = __importStar(require('fs'));
-    var os = __importStar(require('os'));
-    var utils_1 = require_utils();
-    function issueCommand(command, message) {
-      const filePath = process.env[`GITHUB_${command}`];
-      if (!filePath) {
-        throw new Error(`Unable to find environment variable for file command ${command}`);
-      }
-      if (!fs.existsSync(filePath)) {
-        throw new Error(`Missing file at path: ${filePath}`);
-      }
-      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
-        encoding: 'utf8'
-      });
-    }
-    exports2.issueCommand = issueCommand;
-  }
-});
-
 // node_modules/uuid/dist/rng.js
 var require_rng = __commonJS({
   'node_modules/uuid/dist/rng.js'(exports2) {
@@ -724,9 +661,85 @@ var require_dist = __commonJS({
   }
 });
 
-// node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
+// node_modules/@actions/core/lib/file-command.js
+var require_file_command = __commonJS({
+  'node_modules/@actions/core/lib/file-command.js'(exports2) {
+    'use strict';
+    var __createBinding =
+      (exports2 && exports2.__createBinding) ||
+      (Object.create
+        ? function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            Object.defineProperty(o, k2, {
+              enumerable: true,
+              get: function () {
+                return m[k];
+              }
+            });
+          }
+        : function (o, m, k, k2) {
+            if (k2 === void 0) k2 = k;
+            o[k2] = m[k];
+          });
+    var __setModuleDefault =
+      (exports2 && exports2.__setModuleDefault) ||
+      (Object.create
+        ? function (o, v) {
+            Object.defineProperty(o, 'default', { enumerable: true, value: v });
+          }
+        : function (o, v) {
+            o['default'] = v;
+          });
+    var __importStar =
+      (exports2 && exports2.__importStar) ||
+      function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) {
+          for (var k in mod)
+            if (k !== 'default' && Object.hasOwnProperty.call(mod, k))
+              __createBinding(result, mod, k);
+        }
+        __setModuleDefault(result, mod);
+        return result;
+      };
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    exports2.prepareKeyValueMessage = exports2.issueFileCommand = void 0;
+    var fs = __importStar(require('fs'));
+    var os = __importStar(require('os'));
+    var uuid_1 = require_dist();
+    var utils_1 = require_utils();
+    function issueFileCommand(command, message) {
+      const filePath = process.env[`GITHUB_${command}`];
+      if (!filePath) {
+        throw new Error(`Unable to find environment variable for file command ${command}`);
+      }
+      if (!fs.existsSync(filePath)) {
+        throw new Error(`Missing file at path: ${filePath}`);
+      }
+      fs.appendFileSync(filePath, `${utils_1.toCommandValue(message)}${os.EOL}`, {
+        encoding: 'utf8'
+      });
+    }
+    exports2.issueFileCommand = issueFileCommand;
+    function prepareKeyValueMessage(key, value) {
+      const delimiter = `ghadelimiter_${uuid_1.v4()}`;
+      const convertedValue = utils_1.toCommandValue(value);
+      if (key.includes(delimiter)) {
+        throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
+      }
+      if (convertedValue.includes(delimiter)) {
+        throw new Error(`Unexpected input: value should not contain the delimiter "${delimiter}"`);
+      }
+      return `${key}<<${delimiter}${os.EOL}${convertedValue}${os.EOL}${delimiter}`;
+    }
+    exports2.prepareKeyValueMessage = prepareKeyValueMessage;
+  }
+});
+
+// node_modules/@actions/http-client/lib/proxy.js
 var require_proxy = __commonJS({
-  'node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js'(exports2) {
+  'node_modules/@actions/http-client/lib/proxy.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
     exports2.checkBypass = exports2.getProxyUrl = void 0;
@@ -1019,9 +1032,9 @@ var require_tunnel2 = __commonJS({
   }
 });
 
-// node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
+// node_modules/@actions/http-client/lib/index.js
 var require_lib = __commonJS({
-  'node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js'(exports2) {
+  'node_modules/@actions/http-client/lib/index.js'(exports2) {
     'use strict';
     var __createBinding =
       (exports2 && exports2.__createBinding) ||
@@ -1654,9 +1667,9 @@ var require_lib = __commonJS({
   }
 });
 
-// node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
+// node_modules/@actions/http-client/lib/auth.js
 var require_auth = __commonJS({
-  'node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js'(exports2) {
+  'node_modules/@actions/http-client/lib/auth.js'(exports2) {
     'use strict';
     var __awaiter =
       (exports2 && exports2.__awaiter) ||
@@ -2217,7 +2230,6 @@ var require_core = __commonJS({
     var utils_1 = require_utils();
     var os = __importStar(require('os'));
     var path = __importStar(require('path'));
-    var uuid_1 = require_dist();
     var oidc_utils_1 = require_oidc_utils();
     var ExitCode;
     (function (ExitCode2) {
@@ -2229,20 +2241,12 @@ var require_core = __commonJS({
       process.env[name] = convertedVal;
       const filePath = process.env['GITHUB_ENV'] || '';
       if (filePath) {
-        const delimiter = `ghadelimiter_${uuid_1.v4()}`;
-        if (name.includes(delimiter)) {
-          throw new Error(`Unexpected input: name should not contain the delimiter "${delimiter}"`);
-        }
-        if (convertedVal.includes(delimiter)) {
-          throw new Error(
-            `Unexpected input: value should not contain the delimiter "${delimiter}"`
-          );
-        }
-        const commandValue = `${name}<<${delimiter}${os.EOL}${convertedVal}${os.EOL}${delimiter}`;
-        file_command_1.issueCommand('ENV', commandValue);
-      } else {
-        command_1.issueCommand('set-env', { name }, convertedVal);
+        return file_command_1.issueFileCommand(
+          'ENV',
+          file_command_1.prepareKeyValueMessage(name, val)
+        );
       }
+      command_1.issueCommand('set-env', { name }, convertedVal);
     }
     exports2.exportVariable = exportVariable;
     function setSecret(secret) {
@@ -2252,7 +2256,7 @@ var require_core = __commonJS({
     function addPath(inputPath) {
       const filePath = process.env['GITHUB_PATH'] || '';
       if (filePath) {
-        file_command_1.issueCommand('PATH', inputPath);
+        file_command_1.issueFileCommand('PATH', inputPath);
       } else {
         command_1.issueCommand('add-path', {}, inputPath);
       }
@@ -2274,7 +2278,10 @@ var require_core = __commonJS({
       const inputs = getInput(name, options)
         .split('\n')
         .filter(x => x !== '');
-      return inputs;
+      if (options && options.trimWhitespace === false) {
+        return inputs;
+      }
+      return inputs.map(input => input.trim());
     }
     exports2.getMultilineInput = getMultilineInput;
     function getBooleanInput(name, options) {
@@ -2288,8 +2295,15 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports2.getBooleanInput = getBooleanInput;
     function setOutput(name, value) {
+      const filePath = process.env['GITHUB_OUTPUT'] || '';
+      if (filePath) {
+        return file_command_1.issueFileCommand(
+          'OUTPUT',
+          file_command_1.prepareKeyValueMessage(name, value)
+        );
+      }
       process.stdout.write(os.EOL);
-      command_1.issueCommand('set-output', { name }, value);
+      command_1.issueCommand('set-output', { name }, utils_1.toCommandValue(value));
     }
     exports2.setOutput = setOutput;
     function setCommandEcho(enabled) {
@@ -2359,7 +2373,14 @@ Support boolean input list: \`true | True | TRUE | false | False | FALSE\``);
     }
     exports2.group = group;
     function saveState(name, value) {
-      command_1.issueCommand('save-state', { name }, value);
+      const filePath = process.env['GITHUB_STATE'] || '';
+      if (filePath) {
+        return file_command_1.issueFileCommand(
+          'STATE',
+          file_command_1.prepareKeyValueMessage(name, value)
+        );
+      }
+      command_1.issueCommand('save-state', { name }, utils_1.toCommandValue(value));
     }
     exports2.saveState = saveState;
     function getState(name) {
@@ -2478,575 +2499,6 @@ var require_context = __commonJS({
   }
 });
 
-// node_modules/@actions/http-client/proxy.js
-var require_proxy2 = __commonJS({
-  'node_modules/@actions/http-client/proxy.js'(exports2) {
-    'use strict';
-    Object.defineProperty(exports2, '__esModule', { value: true });
-    function getProxyUrl(reqUrl) {
-      let usingSsl = reqUrl.protocol === 'https:';
-      let proxyUrl;
-      if (checkBypass(reqUrl)) {
-        return proxyUrl;
-      }
-      let proxyVar;
-      if (usingSsl) {
-        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
-      } else {
-        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
-      }
-      if (proxyVar) {
-        proxyUrl = new URL(proxyVar);
-      }
-      return proxyUrl;
-    }
-    exports2.getProxyUrl = getProxyUrl;
-    function checkBypass(reqUrl) {
-      if (!reqUrl.hostname) {
-        return false;
-      }
-      let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
-      if (!noProxy) {
-        return false;
-      }
-      let reqPort;
-      if (reqUrl.port) {
-        reqPort = Number(reqUrl.port);
-      } else if (reqUrl.protocol === 'http:') {
-        reqPort = 80;
-      } else if (reqUrl.protocol === 'https:') {
-        reqPort = 443;
-      }
-      let upperReqHosts = [reqUrl.hostname.toUpperCase()];
-      if (typeof reqPort === 'number') {
-        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
-      }
-      for (let upperNoProxyItem of noProxy
-        .split(',')
-        .map(x => x.trim().toUpperCase())
-        .filter(x => x)) {
-        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
-          return true;
-        }
-      }
-      return false;
-    }
-    exports2.checkBypass = checkBypass;
-  }
-});
-
-// node_modules/@actions/http-client/index.js
-var require_http_client = __commonJS({
-  'node_modules/@actions/http-client/index.js'(exports2) {
-    'use strict';
-    Object.defineProperty(exports2, '__esModule', { value: true });
-    var http = require('http');
-    var https = require('https');
-    var pm = require_proxy2();
-    var tunnel;
-    var HttpCodes;
-    (function (HttpCodes2) {
-      HttpCodes2[(HttpCodes2['OK'] = 200)] = 'OK';
-      HttpCodes2[(HttpCodes2['MultipleChoices'] = 300)] = 'MultipleChoices';
-      HttpCodes2[(HttpCodes2['MovedPermanently'] = 301)] = 'MovedPermanently';
-      HttpCodes2[(HttpCodes2['ResourceMoved'] = 302)] = 'ResourceMoved';
-      HttpCodes2[(HttpCodes2['SeeOther'] = 303)] = 'SeeOther';
-      HttpCodes2[(HttpCodes2['NotModified'] = 304)] = 'NotModified';
-      HttpCodes2[(HttpCodes2['UseProxy'] = 305)] = 'UseProxy';
-      HttpCodes2[(HttpCodes2['SwitchProxy'] = 306)] = 'SwitchProxy';
-      HttpCodes2[(HttpCodes2['TemporaryRedirect'] = 307)] = 'TemporaryRedirect';
-      HttpCodes2[(HttpCodes2['PermanentRedirect'] = 308)] = 'PermanentRedirect';
-      HttpCodes2[(HttpCodes2['BadRequest'] = 400)] = 'BadRequest';
-      HttpCodes2[(HttpCodes2['Unauthorized'] = 401)] = 'Unauthorized';
-      HttpCodes2[(HttpCodes2['PaymentRequired'] = 402)] = 'PaymentRequired';
-      HttpCodes2[(HttpCodes2['Forbidden'] = 403)] = 'Forbidden';
-      HttpCodes2[(HttpCodes2['NotFound'] = 404)] = 'NotFound';
-      HttpCodes2[(HttpCodes2['MethodNotAllowed'] = 405)] = 'MethodNotAllowed';
-      HttpCodes2[(HttpCodes2['NotAcceptable'] = 406)] = 'NotAcceptable';
-      HttpCodes2[(HttpCodes2['ProxyAuthenticationRequired'] = 407)] = 'ProxyAuthenticationRequired';
-      HttpCodes2[(HttpCodes2['RequestTimeout'] = 408)] = 'RequestTimeout';
-      HttpCodes2[(HttpCodes2['Conflict'] = 409)] = 'Conflict';
-      HttpCodes2[(HttpCodes2['Gone'] = 410)] = 'Gone';
-      HttpCodes2[(HttpCodes2['TooManyRequests'] = 429)] = 'TooManyRequests';
-      HttpCodes2[(HttpCodes2['InternalServerError'] = 500)] = 'InternalServerError';
-      HttpCodes2[(HttpCodes2['NotImplemented'] = 501)] = 'NotImplemented';
-      HttpCodes2[(HttpCodes2['BadGateway'] = 502)] = 'BadGateway';
-      HttpCodes2[(HttpCodes2['ServiceUnavailable'] = 503)] = 'ServiceUnavailable';
-      HttpCodes2[(HttpCodes2['GatewayTimeout'] = 504)] = 'GatewayTimeout';
-    })((HttpCodes = exports2.HttpCodes || (exports2.HttpCodes = {})));
-    var Headers;
-    (function (Headers2) {
-      Headers2['Accept'] = 'accept';
-      Headers2['ContentType'] = 'content-type';
-    })((Headers = exports2.Headers || (exports2.Headers = {})));
-    var MediaTypes;
-    (function (MediaTypes2) {
-      MediaTypes2['ApplicationJson'] = 'application/json';
-    })((MediaTypes = exports2.MediaTypes || (exports2.MediaTypes = {})));
-    function getProxyUrl(serverUrl) {
-      let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
-      return proxyUrl ? proxyUrl.href : '';
-    }
-    exports2.getProxyUrl = getProxyUrl;
-    var HttpRedirectCodes = [
-      HttpCodes.MovedPermanently,
-      HttpCodes.ResourceMoved,
-      HttpCodes.SeeOther,
-      HttpCodes.TemporaryRedirect,
-      HttpCodes.PermanentRedirect
-    ];
-    var HttpResponseRetryCodes = [
-      HttpCodes.BadGateway,
-      HttpCodes.ServiceUnavailable,
-      HttpCodes.GatewayTimeout
-    ];
-    var RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
-    var ExponentialBackoffCeiling = 10;
-    var ExponentialBackoffTimeSlice = 5;
-    var HttpClientError = class extends Error {
-      constructor(message, statusCode) {
-        super(message);
-        this.name = 'HttpClientError';
-        this.statusCode = statusCode;
-        Object.setPrototypeOf(this, HttpClientError.prototype);
-      }
-    };
-    exports2.HttpClientError = HttpClientError;
-    var HttpClientResponse = class {
-      constructor(message) {
-        this.message = message;
-      }
-      readBody() {
-        return new Promise(async (resolve, reject) => {
-          let output = Buffer.alloc(0);
-          this.message.on('data', chunk => {
-            output = Buffer.concat([output, chunk]);
-          });
-          this.message.on('end', () => {
-            resolve(output.toString());
-          });
-        });
-      }
-    };
-    exports2.HttpClientResponse = HttpClientResponse;
-    function isHttps(requestUrl) {
-      let parsedUrl = new URL(requestUrl);
-      return parsedUrl.protocol === 'https:';
-    }
-    exports2.isHttps = isHttps;
-    var HttpClient = class {
-      constructor(userAgent, handlers, requestOptions) {
-        this._ignoreSslError = false;
-        this._allowRedirects = true;
-        this._allowRedirectDowngrade = false;
-        this._maxRedirects = 50;
-        this._allowRetries = false;
-        this._maxRetries = 1;
-        this._keepAlive = false;
-        this._disposed = false;
-        this.userAgent = userAgent;
-        this.handlers = handlers || [];
-        this.requestOptions = requestOptions;
-        if (requestOptions) {
-          if (requestOptions.ignoreSslError != null) {
-            this._ignoreSslError = requestOptions.ignoreSslError;
-          }
-          this._socketTimeout = requestOptions.socketTimeout;
-          if (requestOptions.allowRedirects != null) {
-            this._allowRedirects = requestOptions.allowRedirects;
-          }
-          if (requestOptions.allowRedirectDowngrade != null) {
-            this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
-          }
-          if (requestOptions.maxRedirects != null) {
-            this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
-          }
-          if (requestOptions.keepAlive != null) {
-            this._keepAlive = requestOptions.keepAlive;
-          }
-          if (requestOptions.allowRetries != null) {
-            this._allowRetries = requestOptions.allowRetries;
-          }
-          if (requestOptions.maxRetries != null) {
-            this._maxRetries = requestOptions.maxRetries;
-          }
-        }
-      }
-      options(requestUrl, additionalHeaders) {
-        return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
-      }
-      get(requestUrl, additionalHeaders) {
-        return this.request('GET', requestUrl, null, additionalHeaders || {});
-      }
-      del(requestUrl, additionalHeaders) {
-        return this.request('DELETE', requestUrl, null, additionalHeaders || {});
-      }
-      post(requestUrl, data, additionalHeaders) {
-        return this.request('POST', requestUrl, data, additionalHeaders || {});
-      }
-      patch(requestUrl, data, additionalHeaders) {
-        return this.request('PATCH', requestUrl, data, additionalHeaders || {});
-      }
-      put(requestUrl, data, additionalHeaders) {
-        return this.request('PUT', requestUrl, data, additionalHeaders || {});
-      }
-      head(requestUrl, additionalHeaders) {
-        return this.request('HEAD', requestUrl, null, additionalHeaders || {});
-      }
-      sendStream(verb, requestUrl, stream, additionalHeaders) {
-        return this.request(verb, requestUrl, stream, additionalHeaders);
-      }
-      async getJson(requestUrl, additionalHeaders = {}) {
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.Accept,
-          MediaTypes.ApplicationJson
-        );
-        let res = await this.get(requestUrl, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-      }
-      async postJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.Accept,
-          MediaTypes.ApplicationJson
-        );
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.ContentType,
-          MediaTypes.ApplicationJson
-        );
-        let res = await this.post(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-      }
-      async putJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.Accept,
-          MediaTypes.ApplicationJson
-        );
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.ContentType,
-          MediaTypes.ApplicationJson
-        );
-        let res = await this.put(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-      }
-      async patchJson(requestUrl, obj, additionalHeaders = {}) {
-        let data = JSON.stringify(obj, null, 2);
-        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.Accept,
-          MediaTypes.ApplicationJson
-        );
-        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
-          additionalHeaders,
-          Headers.ContentType,
-          MediaTypes.ApplicationJson
-        );
-        let res = await this.patch(requestUrl, data, additionalHeaders);
-        return this._processResponse(res, this.requestOptions);
-      }
-      async request(verb, requestUrl, data, headers) {
-        if (this._disposed) {
-          throw new Error('Client has already been disposed.');
-        }
-        let parsedUrl = new URL(requestUrl);
-        let info = this._prepareRequest(verb, parsedUrl, headers);
-        let maxTries =
-          this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1 ? this._maxRetries + 1 : 1;
-        let numTries = 0;
-        let response;
-        while (numTries < maxTries) {
-          response = await this.requestRaw(info, data);
-          if (
-            response &&
-            response.message &&
-            response.message.statusCode === HttpCodes.Unauthorized
-          ) {
-            let authenticationHandler;
-            for (let i = 0; i < this.handlers.length; i++) {
-              if (this.handlers[i].canHandleAuthentication(response)) {
-                authenticationHandler = this.handlers[i];
-                break;
-              }
-            }
-            if (authenticationHandler) {
-              return authenticationHandler.handleAuthentication(this, info, data);
-            } else {
-              return response;
-            }
-          }
-          let redirectsRemaining = this._maxRedirects;
-          while (
-            HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
-            this._allowRedirects &&
-            redirectsRemaining > 0
-          ) {
-            const redirectUrl = response.message.headers['location'];
-            if (!redirectUrl) {
-              break;
-            }
-            let parsedRedirectUrl = new URL(redirectUrl);
-            if (
-              parsedUrl.protocol == 'https:' &&
-              parsedUrl.protocol != parsedRedirectUrl.protocol &&
-              !this._allowRedirectDowngrade
-            ) {
-              throw new Error(
-                'Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.'
-              );
-            }
-            await response.readBody();
-            if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
-              for (let header in headers) {
-                if (header.toLowerCase() === 'authorization') {
-                  delete headers[header];
-                }
-              }
-            }
-            info = this._prepareRequest(verb, parsedRedirectUrl, headers);
-            response = await this.requestRaw(info, data);
-            redirectsRemaining--;
-          }
-          if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
-            return response;
-          }
-          numTries += 1;
-          if (numTries < maxTries) {
-            await response.readBody();
-            await this._performExponentialBackoff(numTries);
-          }
-        }
-        return response;
-      }
-      dispose() {
-        if (this._agent) {
-          this._agent.destroy();
-        }
-        this._disposed = true;
-      }
-      requestRaw(info, data) {
-        return new Promise((resolve, reject) => {
-          let callbackForResult = function (err, res) {
-            if (err) {
-              reject(err);
-            }
-            resolve(res);
-          };
-          this.requestRawWithCallback(info, data, callbackForResult);
-        });
-      }
-      requestRawWithCallback(info, data, onResult) {
-        let socket;
-        if (typeof data === 'string') {
-          info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
-        }
-        let callbackCalled = false;
-        let handleResult = (err, res) => {
-          if (!callbackCalled) {
-            callbackCalled = true;
-            onResult(err, res);
-          }
-        };
-        let req = info.httpModule.request(info.options, msg => {
-          let res = new HttpClientResponse(msg);
-          handleResult(null, res);
-        });
-        req.on('socket', sock => {
-          socket = sock;
-        });
-        req.setTimeout(this._socketTimeout || 3 * 6e4, () => {
-          if (socket) {
-            socket.end();
-          }
-          handleResult(new Error('Request timeout: ' + info.options.path), null);
-        });
-        req.on('error', function (err) {
-          handleResult(err, null);
-        });
-        if (data && typeof data === 'string') {
-          req.write(data, 'utf8');
-        }
-        if (data && typeof data !== 'string') {
-          data.on('close', function () {
-            req.end();
-          });
-          data.pipe(req);
-        } else {
-          req.end();
-        }
-      }
-      getAgent(serverUrl) {
-        let parsedUrl = new URL(serverUrl);
-        return this._getAgent(parsedUrl);
-      }
-      _prepareRequest(method, requestUrl, headers) {
-        const info = {};
-        info.parsedUrl = requestUrl;
-        const usingSsl = info.parsedUrl.protocol === 'https:';
-        info.httpModule = usingSsl ? https : http;
-        const defaultPort = usingSsl ? 443 : 80;
-        info.options = {};
-        info.options.host = info.parsedUrl.hostname;
-        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
-        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
-        info.options.method = method;
-        info.options.headers = this._mergeHeaders(headers);
-        if (this.userAgent != null) {
-          info.options.headers['user-agent'] = this.userAgent;
-        }
-        info.options.agent = this._getAgent(info.parsedUrl);
-        if (this.handlers) {
-          this.handlers.forEach(handler => {
-            handler.prepareRequest(info.options);
-          });
-        }
-        return info;
-      }
-      _mergeHeaders(headers) {
-        const lowercaseKeys = obj =>
-          Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
-        if (this.requestOptions && this.requestOptions.headers) {
-          return Object.assign(
-            {},
-            lowercaseKeys(this.requestOptions.headers),
-            lowercaseKeys(headers)
-          );
-        }
-        return lowercaseKeys(headers || {});
-      }
-      _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
-        const lowercaseKeys = obj =>
-          Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
-        let clientHeader;
-        if (this.requestOptions && this.requestOptions.headers) {
-          clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
-        }
-        return additionalHeaders[header] || clientHeader || _default;
-      }
-      _getAgent(parsedUrl) {
-        let agent;
-        let proxyUrl = pm.getProxyUrl(parsedUrl);
-        let useProxy = proxyUrl && proxyUrl.hostname;
-        if (this._keepAlive && useProxy) {
-          agent = this._proxyAgent;
-        }
-        if (this._keepAlive && !useProxy) {
-          agent = this._agent;
-        }
-        if (!!agent) {
-          return agent;
-        }
-        const usingSsl = parsedUrl.protocol === 'https:';
-        let maxSockets = 100;
-        if (!!this.requestOptions) {
-          maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
-        }
-        if (useProxy) {
-          if (!tunnel) {
-            tunnel = require_tunnel2();
-          }
-          const agentOptions = {
-            maxSockets,
-            keepAlive: this._keepAlive,
-            proxy: {
-              ...((proxyUrl.username || proxyUrl.password) && {
-                proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
-              }),
-              host: proxyUrl.hostname,
-              port: proxyUrl.port
-            }
-          };
-          let tunnelAgent;
-          const overHttps = proxyUrl.protocol === 'https:';
-          if (usingSsl) {
-            tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
-          } else {
-            tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
-          }
-          agent = tunnelAgent(agentOptions);
-          this._proxyAgent = agent;
-        }
-        if (this._keepAlive && !agent) {
-          const options = { keepAlive: this._keepAlive, maxSockets };
-          agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
-          this._agent = agent;
-        }
-        if (!agent) {
-          agent = usingSsl ? https.globalAgent : http.globalAgent;
-        }
-        if (usingSsl && this._ignoreSslError) {
-          agent.options = Object.assign(agent.options || {}, {
-            rejectUnauthorized: false
-          });
-        }
-        return agent;
-      }
-      _performExponentialBackoff(retryNumber) {
-        retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
-        const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
-        return new Promise(resolve => setTimeout(() => resolve(), ms));
-      }
-      static dateTimeDeserializer(key, value) {
-        if (typeof value === 'string') {
-          let a = new Date(value);
-          if (!isNaN(a.valueOf())) {
-            return a;
-          }
-        }
-        return value;
-      }
-      async _processResponse(res, options) {
-        return new Promise(async (resolve, reject) => {
-          const statusCode = res.message.statusCode;
-          const response = {
-            statusCode,
-            result: null,
-            headers: {}
-          };
-          if (statusCode == HttpCodes.NotFound) {
-            resolve(response);
-          }
-          let obj;
-          let contents;
-          try {
-            contents = await res.readBody();
-            if (contents && contents.length > 0) {
-              if (options && options.deserializeDates) {
-                obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
-              } else {
-                obj = JSON.parse(contents);
-              }
-              response.result = obj;
-            }
-            response.headers = res.message.headers;
-          } catch (err) {}
-          if (statusCode > 299) {
-            let msg;
-            if (obj && obj.message) {
-              msg = obj.message;
-            } else if (contents && contents.length > 0) {
-              msg = contents;
-            } else {
-              msg = 'Failed request: (' + statusCode + ')';
-            }
-            let err = new HttpClientError(msg, statusCode);
-            err.result = response.result;
-            reject(err);
-          } else {
-            resolve(response);
-          }
-        });
-      }
-    };
-    exports2.HttpClient = HttpClient;
-  }
-});
-
 // node_modules/@actions/github/lib/internal/utils.js
 var require_utils2 = __commonJS({
   'node_modules/@actions/github/lib/internal/utils.js'(exports2) {
@@ -3091,7 +2543,7 @@ var require_utils2 = __commonJS({
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
     exports2.getApiBaseUrl = exports2.getProxyAgent = exports2.getAuthString = void 0;
-    var httpClient = __importStar(require_http_client());
+    var httpClient = __importStar(require_lib());
     function getAuthString(token2, options) {
       if (!token2 && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -15070,7 +14522,7 @@ var require_dist_node5 = __commonJS({
     var isPlainObject = require_is_plain_object();
     var nodeFetch = _interopDefault(require_lib3());
     var requestError = require_dist_node4();
-    var VERSION = '5.6.1';
+    var VERSION = '5.6.3';
     function getBufferResponse(response) {
       return response.arrayBuffer();
     }
@@ -15343,9 +14795,21 @@ var require_dist_node7 = __commonJS({
   'node_modules/@octokit/auth-token/dist-node/index.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
+    var REGEX_IS_INSTALLATION_LEGACY = /^v1\./;
+    var REGEX_IS_INSTALLATION = /^ghs_/;
+    var REGEX_IS_USER_TO_SERVER = /^ghu_/;
     async function auth(token2) {
-      const tokenType =
-        token2.split(/\./).length === 3 ? 'app' : /^v\d+\./.test(token2) ? 'installation' : 'oauth';
+      const isApp = token2.split(/\./).length === 3;
+      const isInstallation =
+        REGEX_IS_INSTALLATION_LEGACY.test(token2) || REGEX_IS_INSTALLATION.test(token2);
+      const isUserToServer = REGEX_IS_USER_TO_SERVER.test(token2);
+      const tokenType = isApp
+        ? 'app'
+        : isInstallation
+        ? 'installation'
+        : isUserToServer
+        ? 'user-to-server'
+        : 'oauth';
       return {
         type: 'token',
         token: token2,
@@ -15416,7 +14880,7 @@ var require_dist_node8 = __commonJS({
       }
       return target;
     }
-    var VERSION = '3.5.1';
+    var VERSION = '3.6.0';
     var _excluded = ['authStrategy'];
     var Octokit = class {
       constructor(options = {}) {
@@ -15583,6 +15047,12 @@ var require_dist_node9 = __commonJS({
     }
     var Endpoints = {
       actions: {
+        addCustomLabelsToSelfHostedRunnerForOrg: [
+          'POST /orgs/{org}/actions/runners/{runner_id}/labels'
+        ],
+        addCustomLabelsToSelfHostedRunnerForRepo: [
+          'POST /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
+        ],
         addSelectedRepoToOrgSecret: [
           'PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}'
         ],
@@ -15602,6 +15072,8 @@ var require_dist_node9 = __commonJS({
         createWorkflowDispatch: [
           'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches'
         ],
+        deleteActionsCacheById: ['DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}'],
+        deleteActionsCacheByKey: ['DELETE /repos/{owner}/{repo}/actions/caches{?key,ref}'],
         deleteArtifact: ['DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}'],
         deleteEnvironmentSecret: [
           'DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}'
@@ -15622,11 +15094,19 @@ var require_dist_node9 = __commonJS({
           'GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}'
         ],
         downloadJobLogsForWorkflowRun: ['GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs'],
+        downloadWorkflowRunAttemptLogs: [
+          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs'
+        ],
         downloadWorkflowRunLogs: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs'],
         enableSelectedRepositoryGithubActionsOrganization: [
           'PUT /orgs/{org}/actions/permissions/repositories/{repository_id}'
         ],
         enableWorkflow: ['PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable'],
+        getActionsCacheList: ['GET /repos/{owner}/{repo}/actions/caches'],
+        getActionsCacheUsage: ['GET /repos/{owner}/{repo}/actions/cache/usage'],
+        getActionsCacheUsageByRepoForOrg: ['GET /orgs/{org}/actions/cache/usage-by-repository'],
+        getActionsCacheUsageForEnterprise: ['GET /enterprises/{enterprise}/actions/cache/usage'],
+        getActionsCacheUsageForOrg: ['GET /orgs/{org}/actions/cache/usage'],
         getAllowedActionsOrganization: ['GET /orgs/{org}/actions/permissions/selected-actions'],
         getAllowedActionsRepository: [
           'GET /repos/{owner}/{repo}/actions/permissions/selected-actions'
@@ -15637,6 +15117,15 @@ var require_dist_node9 = __commonJS({
         ],
         getEnvironmentSecret: [
           'GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}'
+        ],
+        getGithubActionsDefaultWorkflowPermissionsEnterprise: [
+          'GET /enterprises/{enterprise}/actions/permissions/workflow'
+        ],
+        getGithubActionsDefaultWorkflowPermissionsOrganization: [
+          'GET /orgs/{org}/actions/permissions/workflow'
+        ],
+        getGithubActionsDefaultWorkflowPermissionsRepository: [
+          'GET /repos/{owner}/{repo}/actions/permissions/workflow'
         ],
         getGithubActionsPermissionsOrganization: ['GET /orgs/{org}/actions/permissions'],
         getGithubActionsPermissionsRepository: ['GET /repos/{owner}/{repo}/actions/permissions'],
@@ -15659,7 +15148,11 @@ var require_dist_node9 = __commonJS({
         getSelfHostedRunnerForOrg: ['GET /orgs/{org}/actions/runners/{runner_id}'],
         getSelfHostedRunnerForRepo: ['GET /repos/{owner}/{repo}/actions/runners/{runner_id}'],
         getWorkflow: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}'],
+        getWorkflowAccessToRepository: ['GET /repos/{owner}/{repo}/actions/permissions/access'],
         getWorkflowRun: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}'],
+        getWorkflowRunAttempt: [
+          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}'
+        ],
         getWorkflowRunUsage: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing'],
         getWorkflowUsage: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing'],
         listArtifactsForRepo: ['GET /repos/{owner}/{repo}/actions/artifacts'],
@@ -15667,6 +15160,13 @@ var require_dist_node9 = __commonJS({
           'GET /repositories/{repository_id}/environments/{environment_name}/secrets'
         ],
         listJobsForWorkflowRun: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs'],
+        listJobsForWorkflowRunAttempt: [
+          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs'
+        ],
+        listLabelsForSelfHostedRunnerForOrg: ['GET /orgs/{org}/actions/runners/{runner_id}/labels'],
+        listLabelsForSelfHostedRunnerForRepo: [
+          'GET /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
+        ],
         listOrgSecrets: ['GET /orgs/{org}/actions/secrets'],
         listRepoSecrets: ['GET /repos/{owner}/{repo}/actions/secrets'],
         listRepoWorkflows: ['GET /repos/{owner}/{repo}/actions/workflows'],
@@ -15683,7 +15183,23 @@ var require_dist_node9 = __commonJS({
         listWorkflowRunArtifacts: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts'],
         listWorkflowRuns: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs'],
         listWorkflowRunsForRepo: ['GET /repos/{owner}/{repo}/actions/runs'],
+        reRunJobForWorkflowRun: ['POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun'],
         reRunWorkflow: ['POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun'],
+        reRunWorkflowFailedJobs: [
+          'POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs'
+        ],
+        removeAllCustomLabelsFromSelfHostedRunnerForOrg: [
+          'DELETE /orgs/{org}/actions/runners/{runner_id}/labels'
+        ],
+        removeAllCustomLabelsFromSelfHostedRunnerForRepo: [
+          'DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
+        ],
+        removeCustomLabelFromSelfHostedRunnerForOrg: [
+          'DELETE /orgs/{org}/actions/runners/{runner_id}/labels/{name}'
+        ],
+        removeCustomLabelFromSelfHostedRunnerForRepo: [
+          'DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}'
+        ],
         removeSelectedRepoFromOrgSecret: [
           'DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}'
         ],
@@ -15694,6 +15210,21 @@ var require_dist_node9 = __commonJS({
         setAllowedActionsRepository: [
           'PUT /repos/{owner}/{repo}/actions/permissions/selected-actions'
         ],
+        setCustomLabelsForSelfHostedRunnerForOrg: [
+          'PUT /orgs/{org}/actions/runners/{runner_id}/labels'
+        ],
+        setCustomLabelsForSelfHostedRunnerForRepo: [
+          'PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
+        ],
+        setGithubActionsDefaultWorkflowPermissionsEnterprise: [
+          'PUT /enterprises/{enterprise}/actions/permissions/workflow'
+        ],
+        setGithubActionsDefaultWorkflowPermissionsOrganization: [
+          'PUT /orgs/{org}/actions/permissions/workflow'
+        ],
+        setGithubActionsDefaultWorkflowPermissionsRepository: [
+          'PUT /repos/{owner}/{repo}/actions/permissions/workflow'
+        ],
         setGithubActionsPermissionsOrganization: ['PUT /orgs/{org}/actions/permissions'],
         setGithubActionsPermissionsRepository: ['PUT /repos/{owner}/{repo}/actions/permissions'],
         setSelectedReposForOrgSecret: [
@@ -15701,7 +15232,8 @@ var require_dist_node9 = __commonJS({
         ],
         setSelectedRepositoriesEnabledGithubActionsOrganization: [
           'PUT /orgs/{org}/actions/permissions/repositories'
-        ]
+        ],
+        setWorkflowAccessToRepository: ['PUT /repos/{owner}/{repo}/actions/permissions/access']
       },
       activity: {
         checkRepoIsStarredByAuthenticatedUser: ['GET /user/starred/{owner}/{repo}'],
@@ -15740,25 +15272,16 @@ var require_dist_node9 = __commonJS({
       },
       apps: {
         addRepoToInstallation: [
+          'PUT /user/installations/{installation_id}/repositories/{repository_id}',
+          {},
+          {
+            renamed: ['apps', 'addRepoToInstallationForAuthenticatedUser']
+          }
+        ],
+        addRepoToInstallationForAuthenticatedUser: [
           'PUT /user/installations/{installation_id}/repositories/{repository_id}'
         ],
         checkToken: ['POST /applications/{client_id}/token'],
-        createContentAttachment: [
-          'POST /content_references/{content_reference_id}/attachments',
-          {
-            mediaType: {
-              previews: ['corsair']
-            }
-          }
-        ],
-        createContentAttachmentForRepo: [
-          'POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments',
-          {
-            mediaType: {
-              previews: ['corsair']
-            }
-          }
-        ],
         createFromManifest: ['POST /app-manifests/{code}/conversions'],
         createInstallationAccessToken: ['POST /app/installations/{installation_id}/access_tokens'],
         deleteAuthorization: ['DELETE /applications/{client_id}/grant'],
@@ -15791,6 +15314,13 @@ var require_dist_node9 = __commonJS({
         listWebhookDeliveries: ['GET /app/hook/deliveries'],
         redeliverWebhookDelivery: ['POST /app/hook/deliveries/{delivery_id}/attempts'],
         removeRepoFromInstallation: [
+          'DELETE /user/installations/{installation_id}/repositories/{repository_id}',
+          {},
+          {
+            renamed: ['apps', 'removeRepoFromInstallationForAuthenticatedUser']
+          }
+        ],
+        removeRepoFromInstallationForAuthenticatedUser: [
           'DELETE /user/installations/{installation_id}/repositories/{repository_id}'
         ],
         resetToken: ['PATCH /applications/{client_id}/token'],
@@ -15803,6 +15333,10 @@ var require_dist_node9 = __commonJS({
       billing: {
         getGithubActionsBillingOrg: ['GET /orgs/{org}/settings/billing/actions'],
         getGithubActionsBillingUser: ['GET /users/{username}/settings/billing/actions'],
+        getGithubAdvancedSecurityBillingGhe: [
+          'GET /enterprises/{enterprise}/settings/billing/advanced-security'
+        ],
+        getGithubAdvancedSecurityBillingOrg: ['GET /orgs/{org}/settings/billing/advanced-security'],
         getGithubPackagesBillingOrg: ['GET /orgs/{org}/settings/billing/packages'],
         getGithubPackagesBillingUser: ['GET /users/{username}/settings/billing/packages'],
         getSharedStorageBillingOrg: ['GET /orgs/{org}/settings/billing/shared-storage'],
@@ -15817,6 +15351,7 @@ var require_dist_node9 = __commonJS({
         listForRef: ['GET /repos/{owner}/{repo}/commits/{ref}/check-runs'],
         listForSuite: ['GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs'],
         listSuitesForRef: ['GET /repos/{owner}/{repo}/commits/{ref}/check-suites'],
+        rerequestRun: ['POST /repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest'],
         rerequestSuite: ['POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest'],
         setSuitesPreferences: ['PATCH /repos/{owner}/{repo}/check-suites/preferences'],
         update: ['PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}']
@@ -15839,6 +15374,7 @@ var require_dist_node9 = __commonJS({
         listAlertInstances: [
           'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances'
         ],
+        listAlertsForOrg: ['GET /orgs/{org}/code-scanning/alerts'],
         listAlertsForRepo: ['GET /repos/{owner}/{repo}/code-scanning/alerts'],
         listAlertsInstances: [
           'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances',
@@ -15853,20 +15389,103 @@ var require_dist_node9 = __commonJS({
       },
       codesOfConduct: {
         getAllCodesOfConduct: ['GET /codes_of_conduct'],
-        getConductCode: ['GET /codes_of_conduct/{key}'],
-        getForRepo: [
-          'GET /repos/{owner}/{repo}/community/code_of_conduct',
+        getConductCode: ['GET /codes_of_conduct/{key}']
+      },
+      codespaces: {
+        addRepositoryForSecretForAuthenticatedUser: [
+          'PUT /user/codespaces/secrets/{secret_name}/repositories/{repository_id}'
+        ],
+        codespaceMachinesForAuthenticatedUser: ['GET /user/codespaces/{codespace_name}/machines'],
+        createForAuthenticatedUser: ['POST /user/codespaces'],
+        createOrUpdateRepoSecret: ['PUT /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
+        createOrUpdateSecretForAuthenticatedUser: ['PUT /user/codespaces/secrets/{secret_name}'],
+        createWithPrForAuthenticatedUser: [
+          'POST /repos/{owner}/{repo}/pulls/{pull_number}/codespaces'
+        ],
+        createWithRepoForAuthenticatedUser: ['POST /repos/{owner}/{repo}/codespaces'],
+        deleteForAuthenticatedUser: ['DELETE /user/codespaces/{codespace_name}'],
+        deleteFromOrganization: [
+          'DELETE /orgs/{org}/members/{username}/codespaces/{codespace_name}'
+        ],
+        deleteRepoSecret: ['DELETE /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
+        deleteSecretForAuthenticatedUser: ['DELETE /user/codespaces/secrets/{secret_name}'],
+        exportForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/exports'],
+        getExportDetailsForAuthenticatedUser: [
+          'GET /user/codespaces/{codespace_name}/exports/{export_id}'
+        ],
+        getForAuthenticatedUser: ['GET /user/codespaces/{codespace_name}'],
+        getPublicKeyForAuthenticatedUser: ['GET /user/codespaces/secrets/public-key'],
+        getRepoPublicKey: ['GET /repos/{owner}/{repo}/codespaces/secrets/public-key'],
+        getRepoSecret: ['GET /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
+        getSecretForAuthenticatedUser: ['GET /user/codespaces/secrets/{secret_name}'],
+        listDevcontainersInRepositoryForAuthenticatedUser: [
+          'GET /repos/{owner}/{repo}/codespaces/devcontainers'
+        ],
+        listForAuthenticatedUser: ['GET /user/codespaces'],
+        listInOrganization: [
+          'GET /orgs/{org}/codespaces',
+          {},
           {
-            mediaType: {
-              previews: ['scarlet-witch']
+            renamedParameters: {
+              org_id: 'org'
             }
           }
+        ],
+        listInRepositoryForAuthenticatedUser: ['GET /repos/{owner}/{repo}/codespaces'],
+        listRepoSecrets: ['GET /repos/{owner}/{repo}/codespaces/secrets'],
+        listRepositoriesForSecretForAuthenticatedUser: [
+          'GET /user/codespaces/secrets/{secret_name}/repositories'
+        ],
+        listSecretsForAuthenticatedUser: ['GET /user/codespaces/secrets'],
+        removeRepositoryForSecretForAuthenticatedUser: [
+          'DELETE /user/codespaces/secrets/{secret_name}/repositories/{repository_id}'
+        ],
+        repoMachinesForAuthenticatedUser: ['GET /repos/{owner}/{repo}/codespaces/machines'],
+        setRepositoriesForSecretForAuthenticatedUser: [
+          'PUT /user/codespaces/secrets/{secret_name}/repositories'
+        ],
+        startForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/start'],
+        stopForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/stop'],
+        stopInOrganization: [
+          'POST /orgs/{org}/members/{username}/codespaces/{codespace_name}/stop'
+        ],
+        updateForAuthenticatedUser: ['PATCH /user/codespaces/{codespace_name}']
+      },
+      dependabot: {
+        addSelectedRepoToOrgSecret: [
+          'PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}'
+        ],
+        createOrUpdateOrgSecret: ['PUT /orgs/{org}/dependabot/secrets/{secret_name}'],
+        createOrUpdateRepoSecret: ['PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
+        deleteOrgSecret: ['DELETE /orgs/{org}/dependabot/secrets/{secret_name}'],
+        deleteRepoSecret: ['DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
+        getOrgPublicKey: ['GET /orgs/{org}/dependabot/secrets/public-key'],
+        getOrgSecret: ['GET /orgs/{org}/dependabot/secrets/{secret_name}'],
+        getRepoPublicKey: ['GET /repos/{owner}/{repo}/dependabot/secrets/public-key'],
+        getRepoSecret: ['GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
+        listOrgSecrets: ['GET /orgs/{org}/dependabot/secrets'],
+        listRepoSecrets: ['GET /repos/{owner}/{repo}/dependabot/secrets'],
+        listSelectedReposForOrgSecret: [
+          'GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories'
+        ],
+        removeSelectedRepoFromOrgSecret: [
+          'DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}'
+        ],
+        setSelectedReposForOrgSecret: [
+          'PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories'
         ]
+      },
+      dependencyGraph: {
+        createRepositorySnapshot: ['POST /repos/{owner}/{repo}/dependency-graph/snapshots'],
+        diffRange: ['GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}']
       },
       emojis: {
         get: ['GET /emojis']
       },
       enterpriseAdmin: {
+        addCustomLabelsToSelfHostedRunnerForEnterprise: [
+          'POST /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
+        ],
         disableSelectedOrganizationGithubActionsEnterprise: [
           'DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}'
         ],
@@ -15879,11 +15498,24 @@ var require_dist_node9 = __commonJS({
         getGithubActionsPermissionsEnterprise: [
           'GET /enterprises/{enterprise}/actions/permissions'
         ],
+        getServerStatistics: ['GET /enterprise-installation/{enterprise_or_org}/server-statistics'],
+        listLabelsForSelfHostedRunnerForEnterprise: [
+          'GET /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
+        ],
         listSelectedOrganizationsEnabledGithubActionsEnterprise: [
           'GET /enterprises/{enterprise}/actions/permissions/organizations'
         ],
+        removeAllCustomLabelsFromSelfHostedRunnerForEnterprise: [
+          'DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
+        ],
+        removeCustomLabelFromSelfHostedRunnerForEnterprise: [
+          'DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels/{name}'
+        ],
         setAllowedActionsEnterprise: [
           'PUT /enterprises/{enterprise}/actions/permissions/selected-actions'
+        ],
+        setCustomLabelsForSelfHostedRunnerForEnterprise: [
+          'PUT /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
         ],
         setGithubActionsPermissionsEnterprise: [
           'PUT /enterprises/{enterprise}/actions/permissions'
@@ -15987,14 +15619,7 @@ var require_dist_node9 = __commonJS({
         listCommentsForRepo: ['GET /repos/{owner}/{repo}/issues/comments'],
         listEvents: ['GET /repos/{owner}/{repo}/issues/{issue_number}/events'],
         listEventsForRepo: ['GET /repos/{owner}/{repo}/issues/events'],
-        listEventsForTimeline: [
-          'GET /repos/{owner}/{repo}/issues/{issue_number}/timeline',
-          {
-            mediaType: {
-              previews: ['mockingbird']
-            }
-          }
-        ],
+        listEventsForTimeline: ['GET /repos/{owner}/{repo}/issues/{issue_number}/timeline'],
         listForAuthenticatedUser: ['GET /user/issues'],
         listForOrg: ['GET /orgs/{org}/issues'],
         listForRepo: ['GET /repos/{owner}/{repo}/issues'],
@@ -16037,87 +15662,24 @@ var require_dist_node9 = __commonJS({
       },
       migrations: {
         cancelImport: ['DELETE /repos/{owner}/{repo}/import'],
-        deleteArchiveForAuthenticatedUser: [
-          'DELETE /user/migrations/{migration_id}/archive',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        deleteArchiveForOrg: [
-          'DELETE /orgs/{org}/migrations/{migration_id}/archive',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        downloadArchiveForOrg: [
-          'GET /orgs/{org}/migrations/{migration_id}/archive',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        getArchiveForAuthenticatedUser: [
-          'GET /user/migrations/{migration_id}/archive',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
+        deleteArchiveForAuthenticatedUser: ['DELETE /user/migrations/{migration_id}/archive'],
+        deleteArchiveForOrg: ['DELETE /orgs/{org}/migrations/{migration_id}/archive'],
+        downloadArchiveForOrg: ['GET /orgs/{org}/migrations/{migration_id}/archive'],
+        getArchiveForAuthenticatedUser: ['GET /user/migrations/{migration_id}/archive'],
         getCommitAuthors: ['GET /repos/{owner}/{repo}/import/authors'],
         getImportStatus: ['GET /repos/{owner}/{repo}/import'],
         getLargeFiles: ['GET /repos/{owner}/{repo}/import/large_files'],
-        getStatusForAuthenticatedUser: [
-          'GET /user/migrations/{migration_id}',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        getStatusForOrg: [
-          'GET /orgs/{org}/migrations/{migration_id}',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        listForAuthenticatedUser: [
-          'GET /user/migrations',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        listForOrg: [
-          'GET /orgs/{org}/migrations',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
-        listReposForOrg: [
-          'GET /orgs/{org}/migrations/{migration_id}/repositories',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
+        getStatusForAuthenticatedUser: ['GET /user/migrations/{migration_id}'],
+        getStatusForOrg: ['GET /orgs/{org}/migrations/{migration_id}'],
+        listForAuthenticatedUser: ['GET /user/migrations'],
+        listForOrg: ['GET /orgs/{org}/migrations'],
+        listReposForAuthenticatedUser: ['GET /user/migrations/{migration_id}/repositories'],
+        listReposForOrg: ['GET /orgs/{org}/migrations/{migration_id}/repositories'],
         listReposForUser: [
           'GET /user/migrations/{migration_id}/repositories',
+          {},
           {
-            mediaType: {
-              previews: ['wyandotte']
-            }
+            renamed: ['migrations', 'listReposForAuthenticatedUser']
           }
         ],
         mapCommitAuthor: ['PATCH /repos/{owner}/{repo}/import/authors/{author_id}'],
@@ -16126,21 +15688,9 @@ var require_dist_node9 = __commonJS({
         startForOrg: ['POST /orgs/{org}/migrations'],
         startImport: ['PUT /repos/{owner}/{repo}/import'],
         unlockRepoForAuthenticatedUser: [
-          'DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
+          'DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock'
         ],
-        unlockRepoForOrg: [
-          'DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock',
-          {
-            mediaType: {
-              previews: ['wyandotte']
-            }
-          }
-        ],
+        unlockRepoForOrg: ['DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock'],
         updateImport: ['PATCH /repos/{owner}/{repo}/import']
       },
       orgs: {
@@ -16162,6 +15712,7 @@ var require_dist_node9 = __commonJS({
         list: ['GET /organizations'],
         listAppInstallations: ['GET /orgs/{org}/installations'],
         listBlockedUsers: ['GET /orgs/{org}/blocks'],
+        listCustomRoles: ['GET /organizations/{organization_id}/custom_roles'],
         listFailedInvitations: ['GET /orgs/{org}/failed_invitations'],
         listForAuthenticatedUser: ['GET /user/orgs'],
         listForUser: ['GET /users/{username}/orgs'],
@@ -16241,7 +15792,7 @@ var require_dist_node9 = __commonJS({
         ],
         listPackagesForAuthenticatedUser: ['GET /user/packages'],
         listPackagesForOrganization: ['GET /orgs/{org}/packages'],
-        listPackagesForUser: ['GET /user/{username}/packages'],
+        listPackagesForUser: ['GET /users/{username}/packages'],
         restorePackageForAuthenticatedUser: [
           'POST /user/packages/{package_type}/{package_name}/restore{?token}'
         ],
@@ -16262,206 +15813,31 @@ var require_dist_node9 = __commonJS({
         ]
       },
       projects: {
-        addCollaborator: [
-          'PUT /projects/{project_id}/collaborators/{username}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        createCard: [
-          'POST /projects/columns/{column_id}/cards',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        createColumn: [
-          'POST /projects/{project_id}/columns',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        createForAuthenticatedUser: [
-          'POST /user/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        createForOrg: [
-          'POST /orgs/{org}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        createForRepo: [
-          'POST /repos/{owner}/{repo}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        delete: [
-          'DELETE /projects/{project_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        deleteCard: [
-          'DELETE /projects/columns/cards/{card_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        deleteColumn: [
-          'DELETE /projects/columns/{column_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        get: [
-          'GET /projects/{project_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        getCard: [
-          'GET /projects/columns/cards/{card_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        getColumn: [
-          'GET /projects/columns/{column_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        getPermissionForUser: [
-          'GET /projects/{project_id}/collaborators/{username}/permission',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listCards: [
-          'GET /projects/columns/{column_id}/cards',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listCollaborators: [
-          'GET /projects/{project_id}/collaborators',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listColumns: [
-          'GET /projects/{project_id}/columns',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listForOrg: [
-          'GET /orgs/{org}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listForRepo: [
-          'GET /repos/{owner}/{repo}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        listForUser: [
-          'GET /users/{username}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        moveCard: [
-          'POST /projects/columns/cards/{card_id}/moves',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        moveColumn: [
-          'POST /projects/columns/{column_id}/moves',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        removeCollaborator: [
-          'DELETE /projects/{project_id}/collaborators/{username}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        update: [
-          'PATCH /projects/{project_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        updateCard: [
-          'PATCH /projects/columns/cards/{card_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
-        updateColumn: [
-          'PATCH /projects/columns/{column_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ]
+        addCollaborator: ['PUT /projects/{project_id}/collaborators/{username}'],
+        createCard: ['POST /projects/columns/{column_id}/cards'],
+        createColumn: ['POST /projects/{project_id}/columns'],
+        createForAuthenticatedUser: ['POST /user/projects'],
+        createForOrg: ['POST /orgs/{org}/projects'],
+        createForRepo: ['POST /repos/{owner}/{repo}/projects'],
+        delete: ['DELETE /projects/{project_id}'],
+        deleteCard: ['DELETE /projects/columns/cards/{card_id}'],
+        deleteColumn: ['DELETE /projects/columns/{column_id}'],
+        get: ['GET /projects/{project_id}'],
+        getCard: ['GET /projects/columns/cards/{card_id}'],
+        getColumn: ['GET /projects/columns/{column_id}'],
+        getPermissionForUser: ['GET /projects/{project_id}/collaborators/{username}/permission'],
+        listCards: ['GET /projects/columns/{column_id}/cards'],
+        listCollaborators: ['GET /projects/{project_id}/collaborators'],
+        listColumns: ['GET /projects/{project_id}/columns'],
+        listForOrg: ['GET /orgs/{org}/projects'],
+        listForRepo: ['GET /repos/{owner}/{repo}/projects'],
+        listForUser: ['GET /users/{username}/projects'],
+        moveCard: ['POST /projects/columns/cards/{card_id}/moves'],
+        moveColumn: ['POST /projects/columns/{column_id}/moves'],
+        removeCollaborator: ['DELETE /projects/{project_id}/collaborators/{username}'],
+        update: ['PATCH /projects/{project_id}'],
+        updateCard: ['PATCH /projects/columns/cards/{card_id}'],
+        updateColumn: ['PATCH /projects/columns/{column_id}']
       },
       pulls: {
         checkIfMerged: ['GET /repos/{owner}/{repo}/pulls/{pull_number}/merge'],
@@ -16500,14 +15876,7 @@ var require_dist_node9 = __commonJS({
         requestReviewers: ['POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers'],
         submitReview: ['POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events'],
         update: ['PATCH /repos/{owner}/{repo}/pulls/{pull_number}'],
-        updateBranch: [
-          'PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch',
-          {
-            mediaType: {
-              previews: ['lydian']
-            }
-          }
-        ],
+        updateBranch: ['PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch'],
         updateReview: ['PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}'],
         updateReviewComment: ['PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}']
       },
@@ -16515,173 +15884,67 @@ var require_dist_node9 = __commonJS({
         get: ['GET /rate_limit']
       },
       reactions: {
-        createForCommitComment: [
-          'POST /repos/{owner}/{repo}/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
-        createForIssue: [
-          'POST /repos/{owner}/{repo}/issues/{issue_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
+        createForCommitComment: ['POST /repos/{owner}/{repo}/comments/{comment_id}/reactions'],
+        createForIssue: ['POST /repos/{owner}/{repo}/issues/{issue_number}/reactions'],
         createForIssueComment: [
-          'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'
         ],
         createForPullRequestReviewComment: [
-          'POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions'
         ],
-        createForRelease: [
-          'POST /repos/{owner}/{repo}/releases/{release_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
+        createForRelease: ['POST /repos/{owner}/{repo}/releases/{release_id}/reactions'],
         createForTeamDiscussionCommentInOrg: [
-          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions'
         ],
         createForTeamDiscussionInOrg: [
-          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions'
         ],
         deleteForCommitComment: [
-          'DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}'
         ],
         deleteForIssue: [
-          'DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}'
         ],
         deleteForIssueComment: [
-          'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}'
         ],
         deleteForPullRequestComment: [
-          'DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}'
+        ],
+        deleteForRelease: [
+          'DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}'
         ],
         deleteForTeamDiscussion: [
-          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}'
         ],
         deleteForTeamDiscussionComment: [
-          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}'
         ],
-        deleteLegacy: [
-          'DELETE /reactions/{reaction_id}',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          },
-          {
-            deprecated:
-              'octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/rest/reference/reactions/#delete-a-reaction-legacy'
-          }
-        ],
-        listForCommitComment: [
-          'GET /repos/{owner}/{repo}/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
-        listForIssue: [
-          'GET /repos/{owner}/{repo}/issues/{issue_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
-        listForIssueComment: [
-          'GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
-        ],
+        listForCommitComment: ['GET /repos/{owner}/{repo}/comments/{comment_id}/reactions'],
+        listForIssue: ['GET /repos/{owner}/{repo}/issues/{issue_number}/reactions'],
+        listForIssueComment: ['GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'],
         listForPullRequestReviewComment: [
-          'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions'
         ],
+        listForRelease: ['GET /repos/{owner}/{repo}/releases/{release_id}/reactions'],
         listForTeamDiscussionCommentInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions'
         ],
         listForTeamDiscussionInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions',
-          {
-            mediaType: {
-              previews: ['squirrel-girl']
-            }
-          }
+          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions'
         ]
       },
       repos: {
-        acceptInvitation: ['PATCH /user/repository_invitations/{invitation_id}'],
+        acceptInvitation: [
+          'PATCH /user/repository_invitations/{invitation_id}',
+          {},
+          {
+            renamed: ['repos', 'acceptInvitationForAuthenticatedUser']
+          }
+        ],
+        acceptInvitationForAuthenticatedUser: [
+          'PATCH /user/repository_invitations/{invitation_id}'
+        ],
         addAppAccessRestrictions: [
           'POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps',
           {},
@@ -16712,25 +15975,14 @@ var require_dist_node9 = __commonJS({
           }
         ],
         checkCollaborator: ['GET /repos/{owner}/{repo}/collaborators/{username}'],
-        checkVulnerabilityAlerts: [
-          'GET /repos/{owner}/{repo}/vulnerability-alerts',
-          {
-            mediaType: {
-              previews: ['dorian']
-            }
-          }
-        ],
+        checkVulnerabilityAlerts: ['GET /repos/{owner}/{repo}/vulnerability-alerts'],
+        codeownersErrors: ['GET /repos/{owner}/{repo}/codeowners/errors'],
         compareCommits: ['GET /repos/{owner}/{repo}/compare/{base}...{head}'],
         compareCommitsWithBasehead: ['GET /repos/{owner}/{repo}/compare/{basehead}'],
         createAutolink: ['POST /repos/{owner}/{repo}/autolinks'],
         createCommitComment: ['POST /repos/{owner}/{repo}/commits/{commit_sha}/comments'],
         createCommitSignatureProtection: [
-          'POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
-          {
-            mediaType: {
-              previews: ['zzzax']
-            }
-          }
+          'POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
         ],
         createCommitStatus: ['POST /repos/{owner}/{repo}/statuses/{sha}'],
         createDeployKey: ['POST /repos/{owner}/{repo}/keys'],
@@ -16742,25 +15994,21 @@ var require_dist_node9 = __commonJS({
         createInOrg: ['POST /orgs/{org}/repos'],
         createOrUpdateEnvironment: ['PUT /repos/{owner}/{repo}/environments/{environment_name}'],
         createOrUpdateFileContents: ['PUT /repos/{owner}/{repo}/contents/{path}'],
-        createPagesSite: [
-          'POST /repos/{owner}/{repo}/pages',
-          {
-            mediaType: {
-              previews: ['switcheroo']
-            }
-          }
-        ],
+        createPagesSite: ['POST /repos/{owner}/{repo}/pages'],
         createRelease: ['POST /repos/{owner}/{repo}/releases'],
-        createUsingTemplate: [
-          'POST /repos/{template_owner}/{template_repo}/generate',
+        createTagProtection: ['POST /repos/{owner}/{repo}/tags/protection'],
+        createUsingTemplate: ['POST /repos/{template_owner}/{template_repo}/generate'],
+        createWebhook: ['POST /repos/{owner}/{repo}/hooks'],
+        declineInvitation: [
+          'DELETE /user/repository_invitations/{invitation_id}',
+          {},
           {
-            mediaType: {
-              previews: ['baptiste']
-            }
+            renamed: ['repos', 'declineInvitationForAuthenticatedUser']
           }
         ],
-        createWebhook: ['POST /repos/{owner}/{repo}/hooks'],
-        declineInvitation: ['DELETE /user/repository_invitations/{invitation_id}'],
+        declineInvitationForAuthenticatedUser: [
+          'DELETE /user/repository_invitations/{invitation_id}'
+        ],
         delete: ['DELETE /repos/{owner}/{repo}'],
         deleteAccessRestrictions: [
           'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions'
@@ -16773,47 +16021,23 @@ var require_dist_node9 = __commonJS({
         deleteBranchProtection: ['DELETE /repos/{owner}/{repo}/branches/{branch}/protection'],
         deleteCommitComment: ['DELETE /repos/{owner}/{repo}/comments/{comment_id}'],
         deleteCommitSignatureProtection: [
-          'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
-          {
-            mediaType: {
-              previews: ['zzzax']
-            }
-          }
+          'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
         ],
         deleteDeployKey: ['DELETE /repos/{owner}/{repo}/keys/{key_id}'],
         deleteDeployment: ['DELETE /repos/{owner}/{repo}/deployments/{deployment_id}'],
         deleteFile: ['DELETE /repos/{owner}/{repo}/contents/{path}'],
         deleteInvitation: ['DELETE /repos/{owner}/{repo}/invitations/{invitation_id}'],
-        deletePagesSite: [
-          'DELETE /repos/{owner}/{repo}/pages',
-          {
-            mediaType: {
-              previews: ['switcheroo']
-            }
-          }
-        ],
+        deletePagesSite: ['DELETE /repos/{owner}/{repo}/pages'],
         deletePullRequestReviewProtection: [
           'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews'
         ],
         deleteRelease: ['DELETE /repos/{owner}/{repo}/releases/{release_id}'],
         deleteReleaseAsset: ['DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}'],
+        deleteTagProtection: ['DELETE /repos/{owner}/{repo}/tags/protection/{tag_protection_id}'],
         deleteWebhook: ['DELETE /repos/{owner}/{repo}/hooks/{hook_id}'],
-        disableAutomatedSecurityFixes: [
-          'DELETE /repos/{owner}/{repo}/automated-security-fixes',
-          {
-            mediaType: {
-              previews: ['london']
-            }
-          }
-        ],
-        disableVulnerabilityAlerts: [
-          'DELETE /repos/{owner}/{repo}/vulnerability-alerts',
-          {
-            mediaType: {
-              previews: ['dorian']
-            }
-          }
-        ],
+        disableAutomatedSecurityFixes: ['DELETE /repos/{owner}/{repo}/automated-security-fixes'],
+        disableLfsForRepo: ['DELETE /repos/{owner}/{repo}/lfs'],
+        disableVulnerabilityAlerts: ['DELETE /repos/{owner}/{repo}/vulnerability-alerts'],
         downloadArchive: [
           'GET /repos/{owner}/{repo}/zipball/{ref}',
           {},
@@ -16823,22 +16047,10 @@ var require_dist_node9 = __commonJS({
         ],
         downloadTarballArchive: ['GET /repos/{owner}/{repo}/tarball/{ref}'],
         downloadZipballArchive: ['GET /repos/{owner}/{repo}/zipball/{ref}'],
-        enableAutomatedSecurityFixes: [
-          'PUT /repos/{owner}/{repo}/automated-security-fixes',
-          {
-            mediaType: {
-              previews: ['london']
-            }
-          }
-        ],
-        enableVulnerabilityAlerts: [
-          'PUT /repos/{owner}/{repo}/vulnerability-alerts',
-          {
-            mediaType: {
-              previews: ['dorian']
-            }
-          }
-        ],
+        enableAutomatedSecurityFixes: ['PUT /repos/{owner}/{repo}/automated-security-fixes'],
+        enableLfsForRepo: ['PUT /repos/{owner}/{repo}/lfs'],
+        enableVulnerabilityAlerts: ['PUT /repos/{owner}/{repo}/vulnerability-alerts'],
+        generateReleaseNotes: ['POST /repos/{owner}/{repo}/releases/generate-notes'],
         get: ['GET /repos/{owner}/{repo}'],
         getAccessRestrictions: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions'
@@ -16850,14 +16062,7 @@ var require_dist_node9 = __commonJS({
         getAllStatusCheckContexts: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts'
         ],
-        getAllTopics: [
-          'GET /repos/{owner}/{repo}/topics',
-          {
-            mediaType: {
-              previews: ['mercy']
-            }
-          }
-        ],
+        getAllTopics: ['GET /repos/{owner}/{repo}/topics'],
         getAppsWithAccessToProtectedBranch: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps'
         ],
@@ -16874,12 +16079,7 @@ var require_dist_node9 = __commonJS({
         getCommitActivityStats: ['GET /repos/{owner}/{repo}/stats/commit_activity'],
         getCommitComment: ['GET /repos/{owner}/{repo}/comments/{comment_id}'],
         getCommitSignatureProtection: [
-          'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
-          {
-            mediaType: {
-              previews: ['zzzax']
-            }
-          }
+          'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
         ],
         getCommunityProfileMetrics: ['GET /repos/{owner}/{repo}/community/profile'],
         getContent: ['GET /repos/{owner}/{repo}/contents/{path}'],
@@ -16923,12 +16123,7 @@ var require_dist_node9 = __commonJS({
         listAutolinks: ['GET /repos/{owner}/{repo}/autolinks'],
         listBranches: ['GET /repos/{owner}/{repo}/branches'],
         listBranchesForHeadCommit: [
-          'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head',
-          {
-            mediaType: {
-              previews: ['groot']
-            }
-          }
+          'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head'
         ],
         listCollaborators: ['GET /repos/{owner}/{repo}/collaborators'],
         listCommentsForCommit: ['GET /repos/{owner}/{repo}/commits/{commit_sha}/comments'],
@@ -16949,15 +16144,11 @@ var require_dist_node9 = __commonJS({
         listPagesBuilds: ['GET /repos/{owner}/{repo}/pages/builds'],
         listPublic: ['GET /repositories'],
         listPullRequestsAssociatedWithCommit: [
-          'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
-          {
-            mediaType: {
-              previews: ['groot']
-            }
-          }
+          'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls'
         ],
         listReleaseAssets: ['GET /repos/{owner}/{repo}/releases/{release_id}/assets'],
         listReleases: ['GET /repos/{owner}/{repo}/releases'],
+        listTagProtection: ['GET /repos/{owner}/{repo}/tags/protection'],
         listTags: ['GET /repos/{owner}/{repo}/tags'],
         listTeams: ['GET /repos/{owner}/{repo}/teams'],
         listWebhookDeliveries: ['GET /repos/{owner}/{repo}/hooks/{hook_id}/deliveries'],
@@ -17001,14 +16192,7 @@ var require_dist_node9 = __commonJS({
           }
         ],
         renameBranch: ['POST /repos/{owner}/{repo}/branches/{branch}/rename'],
-        replaceAllTopics: [
-          'PUT /repos/{owner}/{repo}/topics',
-          {
-            mediaType: {
-              previews: ['mercy']
-            }
-          }
-        ],
+        replaceAllTopics: ['PUT /repos/{owner}/{repo}/topics'],
         requestPagesBuild: ['POST /repos/{owner}/{repo}/pages/builds'],
         setAdminBranchProtection: [
           'POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins'
@@ -17074,31 +16258,21 @@ var require_dist_node9 = __commonJS({
       },
       search: {
         code: ['GET /search/code'],
-        commits: [
-          'GET /search/commits',
-          {
-            mediaType: {
-              previews: ['cloak']
-            }
-          }
-        ],
+        commits: ['GET /search/commits'],
         issuesAndPullRequests: ['GET /search/issues'],
         labels: ['GET /search/labels'],
         repos: ['GET /search/repositories'],
-        topics: [
-          'GET /search/topics',
-          {
-            mediaType: {
-              previews: ['mercy']
-            }
-          }
-        ],
+        topics: ['GET /search/topics'],
         users: ['GET /search/users']
       },
       secretScanning: {
         getAlert: ['GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}'],
+        listAlertsForEnterprise: ['GET /enterprises/{enterprise}/secret-scanning/alerts'],
         listAlertsForOrg: ['GET /orgs/{org}/secret-scanning/alerts'],
         listAlertsForRepo: ['GET /repos/{owner}/{repo}/secret-scanning/alerts'],
+        listLocationsForAlert: [
+          'GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations'
+        ],
         updateAlert: ['PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}']
       },
       teams: {
@@ -17106,21 +16280,11 @@ var require_dist_node9 = __commonJS({
           'PUT /orgs/{org}/teams/{team_slug}/memberships/{username}'
         ],
         addOrUpdateProjectPermissionsInOrg: [
-          'PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
+          'PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}'
         ],
         addOrUpdateRepoPermissionsInOrg: ['PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}'],
         checkPermissionsForProjectInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/projects/{project_id}',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
+          'GET /orgs/{org}/teams/{team_slug}/projects/{project_id}'
         ],
         checkPermissionsForRepoInOrg: ['GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}'],
         create: ['POST /orgs/{org}/teams'],
@@ -17150,14 +16314,7 @@ var require_dist_node9 = __commonJS({
         listForAuthenticatedUser: ['GET /user/teams'],
         listMembersInOrg: ['GET /orgs/{org}/teams/{team_slug}/members'],
         listPendingInvitationsInOrg: ['GET /orgs/{org}/teams/{team_slug}/invitations'],
-        listProjectsInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/projects',
-          {
-            mediaType: {
-              previews: ['inertia']
-            }
-          }
-        ],
+        listProjectsInOrg: ['GET /orgs/{org}/teams/{team_slug}/projects'],
         listReposInOrg: ['GET /orgs/{org}/teams/{team_slug}/repos'],
         removeMembershipForUserInOrg: [
           'DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}'
@@ -17173,41 +16330,146 @@ var require_dist_node9 = __commonJS({
         updateInOrg: ['PATCH /orgs/{org}/teams/{team_slug}']
       },
       users: {
-        addEmailForAuthenticated: ['POST /user/emails'],
+        addEmailForAuthenticated: [
+          'POST /user/emails',
+          {},
+          {
+            renamed: ['users', 'addEmailForAuthenticatedUser']
+          }
+        ],
+        addEmailForAuthenticatedUser: ['POST /user/emails'],
         block: ['PUT /user/blocks/{username}'],
         checkBlocked: ['GET /user/blocks/{username}'],
         checkFollowingForUser: ['GET /users/{username}/following/{target_user}'],
         checkPersonIsFollowedByAuthenticated: ['GET /user/following/{username}'],
-        createGpgKeyForAuthenticated: ['POST /user/gpg_keys'],
-        createPublicSshKeyForAuthenticated: ['POST /user/keys'],
-        deleteEmailForAuthenticated: ['DELETE /user/emails'],
-        deleteGpgKeyForAuthenticated: ['DELETE /user/gpg_keys/{gpg_key_id}'],
-        deletePublicSshKeyForAuthenticated: ['DELETE /user/keys/{key_id}'],
+        createGpgKeyForAuthenticated: [
+          'POST /user/gpg_keys',
+          {},
+          {
+            renamed: ['users', 'createGpgKeyForAuthenticatedUser']
+          }
+        ],
+        createGpgKeyForAuthenticatedUser: ['POST /user/gpg_keys'],
+        createPublicSshKeyForAuthenticated: [
+          'POST /user/keys',
+          {},
+          {
+            renamed: ['users', 'createPublicSshKeyForAuthenticatedUser']
+          }
+        ],
+        createPublicSshKeyForAuthenticatedUser: ['POST /user/keys'],
+        deleteEmailForAuthenticated: [
+          'DELETE /user/emails',
+          {},
+          {
+            renamed: ['users', 'deleteEmailForAuthenticatedUser']
+          }
+        ],
+        deleteEmailForAuthenticatedUser: ['DELETE /user/emails'],
+        deleteGpgKeyForAuthenticated: [
+          'DELETE /user/gpg_keys/{gpg_key_id}',
+          {},
+          {
+            renamed: ['users', 'deleteGpgKeyForAuthenticatedUser']
+          }
+        ],
+        deleteGpgKeyForAuthenticatedUser: ['DELETE /user/gpg_keys/{gpg_key_id}'],
+        deletePublicSshKeyForAuthenticated: [
+          'DELETE /user/keys/{key_id}',
+          {},
+          {
+            renamed: ['users', 'deletePublicSshKeyForAuthenticatedUser']
+          }
+        ],
+        deletePublicSshKeyForAuthenticatedUser: ['DELETE /user/keys/{key_id}'],
         follow: ['PUT /user/following/{username}'],
         getAuthenticated: ['GET /user'],
         getByUsername: ['GET /users/{username}'],
         getContextForUser: ['GET /users/{username}/hovercard'],
-        getGpgKeyForAuthenticated: ['GET /user/gpg_keys/{gpg_key_id}'],
-        getPublicSshKeyForAuthenticated: ['GET /user/keys/{key_id}'],
+        getGpgKeyForAuthenticated: [
+          'GET /user/gpg_keys/{gpg_key_id}',
+          {},
+          {
+            renamed: ['users', 'getGpgKeyForAuthenticatedUser']
+          }
+        ],
+        getGpgKeyForAuthenticatedUser: ['GET /user/gpg_keys/{gpg_key_id}'],
+        getPublicSshKeyForAuthenticated: [
+          'GET /user/keys/{key_id}',
+          {},
+          {
+            renamed: ['users', 'getPublicSshKeyForAuthenticatedUser']
+          }
+        ],
+        getPublicSshKeyForAuthenticatedUser: ['GET /user/keys/{key_id}'],
         list: ['GET /users'],
-        listBlockedByAuthenticated: ['GET /user/blocks'],
-        listEmailsForAuthenticated: ['GET /user/emails'],
-        listFollowedByAuthenticated: ['GET /user/following'],
+        listBlockedByAuthenticated: [
+          'GET /user/blocks',
+          {},
+          {
+            renamed: ['users', 'listBlockedByAuthenticatedUser']
+          }
+        ],
+        listBlockedByAuthenticatedUser: ['GET /user/blocks'],
+        listEmailsForAuthenticated: [
+          'GET /user/emails',
+          {},
+          {
+            renamed: ['users', 'listEmailsForAuthenticatedUser']
+          }
+        ],
+        listEmailsForAuthenticatedUser: ['GET /user/emails'],
+        listFollowedByAuthenticated: [
+          'GET /user/following',
+          {},
+          {
+            renamed: ['users', 'listFollowedByAuthenticatedUser']
+          }
+        ],
+        listFollowedByAuthenticatedUser: ['GET /user/following'],
         listFollowersForAuthenticatedUser: ['GET /user/followers'],
         listFollowersForUser: ['GET /users/{username}/followers'],
         listFollowingForUser: ['GET /users/{username}/following'],
-        listGpgKeysForAuthenticated: ['GET /user/gpg_keys'],
+        listGpgKeysForAuthenticated: [
+          'GET /user/gpg_keys',
+          {},
+          {
+            renamed: ['users', 'listGpgKeysForAuthenticatedUser']
+          }
+        ],
+        listGpgKeysForAuthenticatedUser: ['GET /user/gpg_keys'],
         listGpgKeysForUser: ['GET /users/{username}/gpg_keys'],
-        listPublicEmailsForAuthenticated: ['GET /user/public_emails'],
+        listPublicEmailsForAuthenticated: [
+          'GET /user/public_emails',
+          {},
+          {
+            renamed: ['users', 'listPublicEmailsForAuthenticatedUser']
+          }
+        ],
+        listPublicEmailsForAuthenticatedUser: ['GET /user/public_emails'],
         listPublicKeysForUser: ['GET /users/{username}/keys'],
-        listPublicSshKeysForAuthenticated: ['GET /user/keys'],
-        setPrimaryEmailVisibilityForAuthenticated: ['PATCH /user/email/visibility'],
+        listPublicSshKeysForAuthenticated: [
+          'GET /user/keys',
+          {},
+          {
+            renamed: ['users', 'listPublicSshKeysForAuthenticatedUser']
+          }
+        ],
+        listPublicSshKeysForAuthenticatedUser: ['GET /user/keys'],
+        setPrimaryEmailVisibilityForAuthenticated: [
+          'PATCH /user/email/visibility',
+          {},
+          {
+            renamed: ['users', 'setPrimaryEmailVisibilityForAuthenticatedUser']
+          }
+        ],
+        setPrimaryEmailVisibilityForAuthenticatedUser: ['PATCH /user/email/visibility'],
         unblock: ['DELETE /user/blocks/{username}'],
         unfollow: ['DELETE /user/following/{username}'],
         updateAuthenticated: ['PATCH /user']
       }
     };
-    var VERSION = '5.10.0';
+    var VERSION = '5.16.2';
     function endpointsToMethods(octokit, endpointsMap) {
       const newMethods = {};
       for (const [scope, endpoints] of Object.entries(endpointsMap)) {
@@ -17307,34 +16569,31 @@ var require_dist_node10 = __commonJS({
   'node_modules/@octokit/plugin-paginate-rest/dist-node/index.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
-    var VERSION = '2.16.0';
+    var VERSION = '2.21.3';
     function ownKeys(object, enumerableOnly) {
       var keys = Object.keys(object);
       if (Object.getOwnPropertySymbols) {
         var symbols = Object.getOwnPropertySymbols(object);
-        if (enumerableOnly) {
-          symbols = symbols.filter(function (sym) {
+        enumerableOnly &&
+          (symbols = symbols.filter(function (sym) {
             return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-          });
-        }
-        keys.push.apply(keys, symbols);
+          })),
+          keys.push.apply(keys, symbols);
       }
       return keys;
     }
     function _objectSpread2(target) {
       for (var i = 1; i < arguments.length; i++) {
         var source = arguments[i] != null ? arguments[i] : {};
-        if (i % 2) {
-          ownKeys(Object(source), true).forEach(function (key) {
-            _defineProperty(target, key, source[key]);
-          });
-        } else if (Object.getOwnPropertyDescriptors) {
-          Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
-        } else {
-          ownKeys(Object(source)).forEach(function (key) {
-            Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-          });
-        }
+        i % 2
+          ? ownKeys(Object(source), true).forEach(function (key) {
+              _defineProperty(target, key, source[key]);
+            })
+          : Object.getOwnPropertyDescriptors
+          ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source))
+          : ownKeys(Object(source)).forEach(function (key) {
+              Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+            });
       }
       return target;
     }
@@ -17466,7 +16725,9 @@ var require_dist_node10 = __commonJS({
       'GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations',
       'GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners',
       'GET /enterprises/{enterprise}/actions/runners',
-      'GET /enterprises/{enterprise}/actions/runners/downloads',
+      'GET /enterprises/{enterprise}/audit-log',
+      'GET /enterprises/{enterprise}/secret-scanning/alerts',
+      'GET /enterprises/{enterprise}/settings/billing/advanced-security',
       'GET /events',
       'GET /gists',
       'GET /gists/public',
@@ -17476,6 +16737,7 @@ var require_dist_node10 = __commonJS({
       'GET /gists/{gist_id}/forks',
       'GET /installation/repositories',
       'GET /issues',
+      'GET /licenses',
       'GET /marketplace_listing/plans',
       'GET /marketplace_listing/plans/{plan_id}/accounts',
       'GET /marketplace_listing/stubbed/plans',
@@ -17483,17 +16745,23 @@ var require_dist_node10 = __commonJS({
       'GET /networks/{owner}/{repo}/events',
       'GET /notifications',
       'GET /organizations',
+      'GET /orgs/{org}/actions/cache/usage-by-repository',
       'GET /orgs/{org}/actions/permissions/repositories',
       'GET /orgs/{org}/actions/runner-groups',
       'GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories',
       'GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners',
       'GET /orgs/{org}/actions/runners',
-      'GET /orgs/{org}/actions/runners/downloads',
       'GET /orgs/{org}/actions/secrets',
       'GET /orgs/{org}/actions/secrets/{secret_name}/repositories',
+      'GET /orgs/{org}/audit-log',
       'GET /orgs/{org}/blocks',
+      'GET /orgs/{org}/code-scanning/alerts',
+      'GET /orgs/{org}/codespaces',
       'GET /orgs/{org}/credential-authorizations',
+      'GET /orgs/{org}/dependabot/secrets',
+      'GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories',
       'GET /orgs/{org}/events',
+      'GET /orgs/{org}/external-groups',
       'GET /orgs/{org}/failed_invitations',
       'GET /orgs/{org}/hooks',
       'GET /orgs/{org}/hooks/{hook_id}/deliveries',
@@ -17506,10 +16774,12 @@ var require_dist_node10 = __commonJS({
       'GET /orgs/{org}/migrations/{migration_id}/repositories',
       'GET /orgs/{org}/outside_collaborators',
       'GET /orgs/{org}/packages',
+      'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
       'GET /orgs/{org}/projects',
       'GET /orgs/{org}/public_members',
       'GET /orgs/{org}/repos',
       'GET /orgs/{org}/secret-scanning/alerts',
+      'GET /orgs/{org}/settings/billing/advanced-security',
       'GET /orgs/{org}/team-sync/groups',
       'GET /orgs/{org}/teams',
       'GET /orgs/{org}/teams/{team_slug}/discussions',
@@ -17520,41 +16790,45 @@ var require_dist_node10 = __commonJS({
       'GET /orgs/{org}/teams/{team_slug}/members',
       'GET /orgs/{org}/teams/{team_slug}/projects',
       'GET /orgs/{org}/teams/{team_slug}/repos',
-      'GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings',
       'GET /orgs/{org}/teams/{team_slug}/teams',
       'GET /projects/columns/{column_id}/cards',
       'GET /projects/{project_id}/collaborators',
       'GET /projects/{project_id}/columns',
       'GET /repos/{owner}/{repo}/actions/artifacts',
+      'GET /repos/{owner}/{repo}/actions/caches',
       'GET /repos/{owner}/{repo}/actions/runners',
-      'GET /repos/{owner}/{repo}/actions/runners/downloads',
       'GET /repos/{owner}/{repo}/actions/runs',
       'GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts',
+      'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs',
       'GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs',
       'GET /repos/{owner}/{repo}/actions/secrets',
       'GET /repos/{owner}/{repo}/actions/workflows',
       'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
       'GET /repos/{owner}/{repo}/assignees',
-      'GET /repos/{owner}/{repo}/autolinks',
       'GET /repos/{owner}/{repo}/branches',
       'GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations',
       'GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs',
       'GET /repos/{owner}/{repo}/code-scanning/alerts',
       'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances',
       'GET /repos/{owner}/{repo}/code-scanning/analyses',
+      'GET /repos/{owner}/{repo}/codespaces',
+      'GET /repos/{owner}/{repo}/codespaces/devcontainers',
+      'GET /repos/{owner}/{repo}/codespaces/secrets',
       'GET /repos/{owner}/{repo}/collaborators',
       'GET /repos/{owner}/{repo}/comments',
       'GET /repos/{owner}/{repo}/comments/{comment_id}/reactions',
       'GET /repos/{owner}/{repo}/commits',
-      'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head',
       'GET /repos/{owner}/{repo}/commits/{commit_sha}/comments',
       'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
       'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',
       'GET /repos/{owner}/{repo}/commits/{ref}/check-suites',
+      'GET /repos/{owner}/{repo}/commits/{ref}/status',
       'GET /repos/{owner}/{repo}/commits/{ref}/statuses',
       'GET /repos/{owner}/{repo}/contributors',
+      'GET /repos/{owner}/{repo}/dependabot/secrets',
       'GET /repos/{owner}/{repo}/deployments',
       'GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses',
+      'GET /repos/{owner}/{repo}/environments',
       'GET /repos/{owner}/{repo}/events',
       'GET /repos/{owner}/{repo}/forks',
       'GET /repos/{owner}/{repo}/git/matching-refs/{ref}',
@@ -17588,16 +16862,16 @@ var require_dist_node10 = __commonJS({
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments',
       'GET /repos/{owner}/{repo}/releases',
       'GET /repos/{owner}/{repo}/releases/{release_id}/assets',
+      'GET /repos/{owner}/{repo}/releases/{release_id}/reactions',
       'GET /repos/{owner}/{repo}/secret-scanning/alerts',
+      'GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations',
       'GET /repos/{owner}/{repo}/stargazers',
       'GET /repos/{owner}/{repo}/subscribers',
       'GET /repos/{owner}/{repo}/tags',
       'GET /repos/{owner}/{repo}/teams',
+      'GET /repos/{owner}/{repo}/topics',
       'GET /repositories',
       'GET /repositories/{repository_id}/environments/{environment_name}/secrets',
-      'GET /scim/v2/enterprises/{enterprise}/Groups',
-      'GET /scim/v2/enterprises/{enterprise}/Users',
-      'GET /scim/v2/organizations/{org}/Users',
       'GET /search/code',
       'GET /search/commits',
       'GET /search/issues',
@@ -17613,9 +16887,10 @@ var require_dist_node10 = __commonJS({
       'GET /teams/{team_id}/members',
       'GET /teams/{team_id}/projects',
       'GET /teams/{team_id}/repos',
-      'GET /teams/{team_id}/team-sync/group-mappings',
       'GET /teams/{team_id}/teams',
       'GET /user/blocks',
+      'GET /user/codespaces',
+      'GET /user/codespaces/secrets',
       'GET /user/emails',
       'GET /user/followers',
       'GET /user/following',
@@ -17631,13 +16906,13 @@ var require_dist_node10 = __commonJS({
       'GET /user/migrations/{migration_id}/repositories',
       'GET /user/orgs',
       'GET /user/packages',
+      'GET /user/packages/{package_type}/{package_name}/versions',
       'GET /user/public_emails',
       'GET /user/repos',
       'GET /user/repository_invitations',
       'GET /user/starred',
       'GET /user/subscriptions',
       'GET /user/teams',
-      'GET /user/{username}/packages',
       'GET /users',
       'GET /users/{username}/events',
       'GET /users/{username}/events/orgs/{org}',
@@ -17648,6 +16923,7 @@ var require_dist_node10 = __commonJS({
       'GET /users/{username}/gpg_keys',
       'GET /users/{username}/keys',
       'GET /users/{username}/orgs',
+      'GET /users/{username}/packages',
       'GET /users/{username}/projects',
       'GET /users/{username}/received_events',
       'GET /users/{username}/received_events/public',
@@ -17720,7 +16996,7 @@ var require_utils4 = __commonJS({
         return result;
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
-    exports2.getOctokitOptions = exports2.GitHub = exports2.context = void 0;
+    exports2.getOctokitOptions = exports2.GitHub = exports2.defaults = exports2.context = void 0;
     var Context = __importStar(require_context());
     var Utils = __importStar(require_utils2());
     var core_1 = require_dist_node8();
@@ -17728,7 +17004,7 @@ var require_utils4 = __commonJS({
     var plugin_paginate_rest_1 = require_dist_node10();
     exports2.context = new Context.Context();
     var baseUrl = Utils.getApiBaseUrl();
-    var defaults = {
+    exports2.defaults = {
       baseUrl,
       request: {
         agent: Utils.getProxyAgent(baseUrl)
@@ -17737,7 +17013,7 @@ var require_utils4 = __commonJS({
     exports2.GitHub = core_1.Octokit.plugin(
       plugin_rest_endpoint_methods_1.restEndpointMethods,
       plugin_paginate_rest_1.paginateRest
-    ).defaults(defaults);
+    ).defaults(exports2.defaults);
     function getOctokitOptions(token2, options) {
       const opts = Object.assign({}, options || {});
       const auth = Utils.getAuthString(token2, opts);
@@ -17797,8 +17073,9 @@ var require_github = __commonJS({
     var Context = __importStar(require_context());
     var utils_1 = require_utils4();
     exports2.context = new Context.Context();
-    function getOctokit(token2, options) {
-      return new utils_1.GitHub(utils_1.getOctokitOptions(token2, options));
+    function getOctokit(token2, options, ...additionalPlugins) {
+      const GitHubWithPlugins = utils_1.GitHub.plugin(...additionalPlugins);
+      return new GitHubWithPlugins(utils_1.getOctokitOptions(token2, options));
     }
     exports2.getOctokit = getOctokit;
   }
@@ -17945,7 +17222,7 @@ var require_re = __commonJS({
     var R = 0;
     var createToken = (name, value, isGlobal) => {
       const index = R++;
-      debug(index, value);
+      debug(name, index, value);
       t[name] = index;
       src[index] = value;
       re[index] = new RegExp(value, isGlobal ? 'g' : void 0);
@@ -18036,8 +17313,8 @@ var require_re = __commonJS({
       `^\\s*(${src[t.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t.XRANGEPLAINLOOSE]})\\s*$`
     );
     createToken('STAR', '(<|>)?=?\\s*\\*');
-    createToken('GTE0', '^\\s*>=\\s*0.0.0\\s*$');
-    createToken('GTE0PRE', '^\\s*>=\\s*0.0.0-0\\s*$');
+    createToken('GTE0', '^\\s*>=\\s*0\\.0\\.0\\s*$');
+    createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$');
   }
 });
 
@@ -18052,9 +17329,9 @@ var require_parse_options = __commonJS({
         ? { loose: true }
         : opts
             .filter(k => options[k])
-            .reduce((options2, k) => {
-              options2[k] = true;
-              return options2;
+            .reduce((o, k) => {
+              o[k] = true;
+              return o;
             }, {});
     module2.exports = parseOptions;
   }
@@ -18291,7 +17568,7 @@ var require_semver = __commonJS({
               }
             }
             if (identifier) {
-              if (this.prerelease[0] === identifier) {
+              if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
                 if (isNaN(this.prerelease[1])) {
                   this.prerelease = [identifier, 0];
                 }
@@ -18378,7 +17655,10 @@ var require_inc = __commonJS({
         options = void 0;
       }
       try {
-        return new SemVer(version, options).inc(release, identifier).version;
+        return new SemVer(version instanceof SemVer ? version.version : version, options).inc(
+          release,
+          identifier
+        ).version;
       } catch (er) {
         return null;
       }
@@ -18578,12 +17858,20 @@ var require_cmp = __commonJS({
     var cmp = (a, op, b, loose) => {
       switch (op) {
         case '===':
-          if (typeof a === 'object') a = a.version;
-          if (typeof b === 'object') b = b.version;
+          if (typeof a === 'object') {
+            a = a.version;
+          }
+          if (typeof b === 'object') {
+            b = b.version;
+          }
           return a === b;
         case '!==':
-          if (typeof a === 'object') a = a.version;
-          if (typeof b === 'object') b = b.version;
+          if (typeof a === 'object') {
+            a = a.version;
+          }
+          if (typeof b === 'object') {
+            b = b.version;
+          }
           return a !== b;
         case '':
         case '=':
@@ -18640,7 +17928,9 @@ var require_coerce = __commonJS({
         }
         re[t.COERCERTL].lastIndex = -1;
       }
-      if (match === null) return null;
+      if (match === null) {
+        return null;
+      }
       return parse(`${match[2]}.${match[3] || '0'}.${match[4] || '0'}`, options);
     };
     module2.exports = coerce;
@@ -19317,8 +18607,8 @@ var require_range = __commonJS({
         this.includePrerelease = !!options.includePrerelease;
         this.raw = range;
         this.set = range
-          .split(/\s*\|\|\s*/)
-          .map(range2 => this.parseRange(range2.trim()))
+          .split('||')
+          .map(r => this.parseRange(r.trim()))
           .filter(c => c.length);
         if (!this.set.length) {
           throw new TypeError(`Invalid SemVer Range: ${range}`);
@@ -19326,8 +18616,9 @@ var require_range = __commonJS({
         if (this.set.length > 1) {
           const first = this.set[0];
           this.set = this.set.filter(c => !isNullSet(c[0]));
-          if (this.set.length === 0) this.set = [first];
-          else if (this.set.length > 1) {
+          if (this.set.length === 0) {
+            this.set = [first];
+          } else if (this.set.length > 1) {
             for (const c of this.set) {
               if (c.length === 1 && isAny(c[0])) {
                 this.set = [c];
@@ -19355,32 +18646,42 @@ var require_range = __commonJS({
         const memoOpts = Object.keys(this.options).join(',');
         const memoKey = `parseRange:${memoOpts}:${range}`;
         const cached = cache.get(memoKey);
-        if (cached) return cached;
+        if (cached) {
+          return cached;
+        }
         const loose = this.options.loose;
         const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
         range = range.replace(hr, hyphenReplace(this.options.includePrerelease));
         debug('hyphen replace', range);
         range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
-        debug('comparator trim', range, re[t.COMPARATORTRIM]);
+        debug('comparator trim', range);
         range = range.replace(re[t.TILDETRIM], tildeTrimReplace);
         range = range.replace(re[t.CARETTRIM], caretTrimReplace);
         range = range.split(/\s+/).join(' ');
-        const compRe = loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
-        const rangeList = range
+        let rangeList = range
           .split(' ')
           .map(comp => parseComparator(comp, this.options))
           .join(' ')
           .split(/\s+/)
-          .map(comp => replaceGTE0(comp, this.options))
-          .filter(this.options.loose ? comp => !!comp.match(compRe) : () => true)
-          .map(comp => new Comparator(comp, this.options));
-        const l = rangeList.length;
+          .map(comp => replaceGTE0(comp, this.options));
+        if (loose) {
+          rangeList = rangeList.filter(comp => {
+            debug('loose invalid filter', comp, this.options);
+            return !!comp.match(re[t.COMPARATORLOOSE]);
+          });
+        }
+        debug('range list', rangeList);
         const rangeMap = new Map();
-        for (const comp of rangeList) {
-          if (isNullSet(comp)) return [comp];
+        const comparators = rangeList.map(comp => new Comparator(comp, this.options));
+        for (const comp of comparators) {
+          if (isNullSet(comp)) {
+            return [comp];
+          }
           rangeMap.set(comp.value, comp);
         }
-        if (rangeMap.size > 1 && rangeMap.has('')) rangeMap.delete('');
+        if (rangeMap.size > 1 && rangeMap.has('')) {
+          rangeMap.delete('');
+        }
         const result = [...rangeMap.values()];
         cache.set(memoKey, result);
         return result;
@@ -19463,8 +18764,8 @@ var require_range = __commonJS({
       comp
         .trim()
         .split(/\s+/)
-        .map(comp2 => {
-          return replaceTilde(comp2, options);
+        .map(c => {
+          return replaceTilde(c, options);
         })
         .join(' ');
     var replaceTilde = (comp, options) => {
@@ -19492,8 +18793,8 @@ var require_range = __commonJS({
       comp
         .trim()
         .split(/\s+/)
-        .map(comp2 => {
-          return replaceCaret(comp2, options);
+        .map(c => {
+          return replaceCaret(c, options);
         })
         .join(' ');
     var replaceCaret = (comp, options) => {
@@ -19544,8 +18845,8 @@ var require_range = __commonJS({
       debug('replaceXRanges', comp, options);
       return comp
         .split(/\s+/)
-        .map(comp2 => {
-          return replaceXRange(comp2, options);
+        .map(c => {
+          return replaceXRange(c, options);
         })
         .join(' ');
     };
@@ -19591,7 +18892,9 @@ var require_range = __commonJS({
               m = +m + 1;
             }
           }
-          if (gtlt === '<') pr = '-0';
+          if (gtlt === '<') {
+            pr = '-0';
+          }
           ret = `${gtlt + M}.${m}.${p}${pr}`;
         } else if (xm) {
           ret = `>=${M}.0.0${pr} <${+M + 1}.0.0-0`;
@@ -19917,7 +19220,9 @@ var require_min_version = __commonJS({
               throw new Error(`Unexpected operation: ${comparator.operator}`);
           }
         });
-        if (setMin && (!minver || gt(minver, setMin))) minver = setMin;
+        if (setMin && (!minver || gt(minver, setMin))) {
+          minver = setMin;
+        }
       }
       if (minver && range.test(minver)) {
         return minver;
@@ -20049,30 +19354,40 @@ var require_simplify = __commonJS({
     var compare = require_compare();
     module2.exports = (versions, range, options) => {
       const set = [];
-      let min = null;
+      let first = null;
       let prev = null;
       const v = versions.sort((a, b) => compare(a, b, options));
       for (const version of v) {
         const included = satisfies(version, range, options);
         if (included) {
           prev = version;
-          if (!min) min = version;
+          if (!first) {
+            first = version;
+          }
         } else {
           if (prev) {
-            set.push([min, prev]);
+            set.push([first, prev]);
           }
           prev = null;
-          min = null;
+          first = null;
         }
       }
-      if (min) set.push([min, null]);
+      if (first) {
+        set.push([first, null]);
+      }
       const ranges = [];
-      for (const [min2, max] of set) {
-        if (min2 === max) ranges.push(min2);
-        else if (!max && min2 === v[0]) ranges.push('*');
-        else if (!max) ranges.push(`>=${min2}`);
-        else if (min2 === v[0]) ranges.push(`<=${max}`);
-        else ranges.push(`${min2} - ${max}`);
+      for (const [min, max] of set) {
+        if (min === max) {
+          ranges.push(min);
+        } else if (!max && min === v[0]) {
+          ranges.push('*');
+        } else if (!max) {
+          ranges.push(`>=${min}`);
+        } else if (min === v[0]) {
+          ranges.push(`<=${max}`);
+        } else {
+          ranges.push(`${min} - ${max}`);
+        }
       }
       const simplified = ranges.join(' || ');
       const original = typeof range.raw === 'string' ? range.raw : String(range);
@@ -20090,7 +19405,9 @@ var require_subset = __commonJS({
     var satisfies = require_satisfies();
     var compare = require_compare();
     var subset = (sub, dom, options = {}) => {
-      if (sub === dom) return true;
+      if (sub === dom) {
+        return true;
+      }
       sub = new Range(sub, options);
       dom = new Range(dom, options);
       let sawNonNull = false;
@@ -20098,42 +19415,70 @@ var require_subset = __commonJS({
         for (const simpleDom of dom.set) {
           const isSub = simpleSubset(simpleSub, simpleDom, options);
           sawNonNull = sawNonNull || isSub !== null;
-          if (isSub) continue OUTER;
+          if (isSub) {
+            continue OUTER;
+          }
         }
-        if (sawNonNull) return false;
+        if (sawNonNull) {
+          return false;
+        }
       }
       return true;
     };
     var simpleSubset = (sub, dom, options) => {
-      if (sub === dom) return true;
+      if (sub === dom) {
+        return true;
+      }
       if (sub.length === 1 && sub[0].semver === ANY) {
-        if (dom.length === 1 && dom[0].semver === ANY) return true;
-        else if (options.includePrerelease) sub = [new Comparator('>=0.0.0-0')];
-        else sub = [new Comparator('>=0.0.0')];
+        if (dom.length === 1 && dom[0].semver === ANY) {
+          return true;
+        } else if (options.includePrerelease) {
+          sub = [new Comparator('>=0.0.0-0')];
+        } else {
+          sub = [new Comparator('>=0.0.0')];
+        }
       }
       if (dom.length === 1 && dom[0].semver === ANY) {
-        if (options.includePrerelease) return true;
-        else dom = [new Comparator('>=0.0.0')];
+        if (options.includePrerelease) {
+          return true;
+        } else {
+          dom = [new Comparator('>=0.0.0')];
+        }
       }
       const eqSet = new Set();
       let gt, lt;
       for (const c of sub) {
-        if (c.operator === '>' || c.operator === '>=') gt = higherGT(gt, c, options);
-        else if (c.operator === '<' || c.operator === '<=') lt = lowerLT(lt, c, options);
-        else eqSet.add(c.semver);
+        if (c.operator === '>' || c.operator === '>=') {
+          gt = higherGT(gt, c, options);
+        } else if (c.operator === '<' || c.operator === '<=') {
+          lt = lowerLT(lt, c, options);
+        } else {
+          eqSet.add(c.semver);
+        }
       }
-      if (eqSet.size > 1) return null;
+      if (eqSet.size > 1) {
+        return null;
+      }
       let gtltComp;
       if (gt && lt) {
         gtltComp = compare(gt.semver, lt.semver, options);
-        if (gtltComp > 0) return null;
-        else if (gtltComp === 0 && (gt.operator !== '>=' || lt.operator !== '<=')) return null;
+        if (gtltComp > 0) {
+          return null;
+        } else if (gtltComp === 0 && (gt.operator !== '>=' || lt.operator !== '<=')) {
+          return null;
+        }
       }
       for (const eq of eqSet) {
-        if (gt && !satisfies(eq, String(gt), options)) return null;
-        if (lt && !satisfies(eq, String(lt), options)) return null;
+        if (gt && !satisfies(eq, String(gt), options)) {
+          return null;
+        }
+        if (lt && !satisfies(eq, String(lt), options)) {
+          return null;
+        }
         for (const c of dom) {
-          if (!satisfies(eq, String(c), options)) return false;
+          if (!satisfies(eq, String(c), options)) {
+            return false;
+          }
         }
         return true;
       }
@@ -20168,9 +19513,12 @@ var require_subset = __commonJS({
           }
           if (c.operator === '>' || c.operator === '>=') {
             higher = higherGT(gt, c, options);
-            if (higher === c && higher !== gt) return false;
-          } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options))
+            if (higher === c && higher !== gt) {
+              return false;
+            }
+          } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options)) {
             return false;
+          }
         }
         if (lt) {
           if (needDomLTPre) {
@@ -20186,24 +19534,39 @@ var require_subset = __commonJS({
           }
           if (c.operator === '<' || c.operator === '<=') {
             lower = lowerLT(lt, c, options);
-            if (lower === c && lower !== lt) return false;
-          } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options))
+            if (lower === c && lower !== lt) {
+              return false;
+            }
+          } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options)) {
             return false;
+          }
         }
-        if (!c.operator && (lt || gt) && gtltComp !== 0) return false;
+        if (!c.operator && (lt || gt) && gtltComp !== 0) {
+          return false;
+        }
       }
-      if (gt && hasDomLT && !lt && gtltComp !== 0) return false;
-      if (lt && hasDomGT && !gt && gtltComp !== 0) return false;
-      if (needDomGTPre || needDomLTPre) return false;
+      if (gt && hasDomLT && !lt && gtltComp !== 0) {
+        return false;
+      }
+      if (lt && hasDomGT && !gt && gtltComp !== 0) {
+        return false;
+      }
+      if (needDomGTPre || needDomLTPre) {
+        return false;
+      }
       return true;
     };
     var higherGT = (a, b, options) => {
-      if (!a) return b;
+      if (!a) {
+        return b;
+      }
       const comp = compare(a.semver, b.semver, options);
       return comp > 0 ? a : comp < 0 ? b : b.operator === '>' && a.operator === '>=' ? b : a;
     };
     var lowerLT = (a, b, options) => {
-      if (!a) return b;
+      if (!a) {
+        return b;
+      }
       const comp = compare(a.semver, b.semver, options);
       return comp < 0 ? a : comp > 0 ? b : b.operator === '<' && a.operator === '<=' ? b : a;
     };

--- a/dist/index.js
+++ b/dist/index.js
@@ -737,9 +737,9 @@ var require_file_command = __commonJS({
   }
 });
 
-// node_modules/@actions/http-client/lib/proxy.js
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js
 var require_proxy = __commonJS({
-  'node_modules/@actions/http-client/lib/proxy.js'(exports2) {
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/proxy.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
     exports2.checkBypass = exports2.getProxyUrl = void 0;
@@ -1032,9 +1032,9 @@ var require_tunnel2 = __commonJS({
   }
 });
 
-// node_modules/@actions/http-client/lib/index.js
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js
 var require_lib = __commonJS({
-  'node_modules/@actions/http-client/lib/index.js'(exports2) {
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/index.js'(exports2) {
     'use strict';
     var __createBinding =
       (exports2 && exports2.__createBinding) ||
@@ -1667,9 +1667,9 @@ var require_lib = __commonJS({
   }
 });
 
-// node_modules/@actions/http-client/lib/auth.js
+// node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js
 var require_auth = __commonJS({
-  'node_modules/@actions/http-client/lib/auth.js'(exports2) {
+  'node_modules/@actions/core/node_modules/@actions/http-client/lib/auth.js'(exports2) {
     'use strict';
     var __awaiter =
       (exports2 && exports2.__awaiter) ||
@@ -2499,6 +2499,575 @@ var require_context = __commonJS({
   }
 });
 
+// node_modules/@actions/http-client/proxy.js
+var require_proxy2 = __commonJS({
+  'node_modules/@actions/http-client/proxy.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    function getProxyUrl(reqUrl) {
+      let usingSsl = reqUrl.protocol === 'https:';
+      let proxyUrl;
+      if (checkBypass(reqUrl)) {
+        return proxyUrl;
+      }
+      let proxyVar;
+      if (usingSsl) {
+        proxyVar = process.env['https_proxy'] || process.env['HTTPS_PROXY'];
+      } else {
+        proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
+      }
+      if (proxyVar) {
+        proxyUrl = new URL(proxyVar);
+      }
+      return proxyUrl;
+    }
+    exports2.getProxyUrl = getProxyUrl;
+    function checkBypass(reqUrl) {
+      if (!reqUrl.hostname) {
+        return false;
+      }
+      let noProxy = process.env['no_proxy'] || process.env['NO_PROXY'] || '';
+      if (!noProxy) {
+        return false;
+      }
+      let reqPort;
+      if (reqUrl.port) {
+        reqPort = Number(reqUrl.port);
+      } else if (reqUrl.protocol === 'http:') {
+        reqPort = 80;
+      } else if (reqUrl.protocol === 'https:') {
+        reqPort = 443;
+      }
+      let upperReqHosts = [reqUrl.hostname.toUpperCase()];
+      if (typeof reqPort === 'number') {
+        upperReqHosts.push(`${upperReqHosts[0]}:${reqPort}`);
+      }
+      for (let upperNoProxyItem of noProxy
+        .split(',')
+        .map(x => x.trim().toUpperCase())
+        .filter(x => x)) {
+        if (upperReqHosts.some(x => x === upperNoProxyItem)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    exports2.checkBypass = checkBypass;
+  }
+});
+
+// node_modules/@actions/http-client/index.js
+var require_http_client = __commonJS({
+  'node_modules/@actions/http-client/index.js'(exports2) {
+    'use strict';
+    Object.defineProperty(exports2, '__esModule', { value: true });
+    var http = require('http');
+    var https = require('https');
+    var pm = require_proxy2();
+    var tunnel;
+    var HttpCodes;
+    (function (HttpCodes2) {
+      HttpCodes2[(HttpCodes2['OK'] = 200)] = 'OK';
+      HttpCodes2[(HttpCodes2['MultipleChoices'] = 300)] = 'MultipleChoices';
+      HttpCodes2[(HttpCodes2['MovedPermanently'] = 301)] = 'MovedPermanently';
+      HttpCodes2[(HttpCodes2['ResourceMoved'] = 302)] = 'ResourceMoved';
+      HttpCodes2[(HttpCodes2['SeeOther'] = 303)] = 'SeeOther';
+      HttpCodes2[(HttpCodes2['NotModified'] = 304)] = 'NotModified';
+      HttpCodes2[(HttpCodes2['UseProxy'] = 305)] = 'UseProxy';
+      HttpCodes2[(HttpCodes2['SwitchProxy'] = 306)] = 'SwitchProxy';
+      HttpCodes2[(HttpCodes2['TemporaryRedirect'] = 307)] = 'TemporaryRedirect';
+      HttpCodes2[(HttpCodes2['PermanentRedirect'] = 308)] = 'PermanentRedirect';
+      HttpCodes2[(HttpCodes2['BadRequest'] = 400)] = 'BadRequest';
+      HttpCodes2[(HttpCodes2['Unauthorized'] = 401)] = 'Unauthorized';
+      HttpCodes2[(HttpCodes2['PaymentRequired'] = 402)] = 'PaymentRequired';
+      HttpCodes2[(HttpCodes2['Forbidden'] = 403)] = 'Forbidden';
+      HttpCodes2[(HttpCodes2['NotFound'] = 404)] = 'NotFound';
+      HttpCodes2[(HttpCodes2['MethodNotAllowed'] = 405)] = 'MethodNotAllowed';
+      HttpCodes2[(HttpCodes2['NotAcceptable'] = 406)] = 'NotAcceptable';
+      HttpCodes2[(HttpCodes2['ProxyAuthenticationRequired'] = 407)] = 'ProxyAuthenticationRequired';
+      HttpCodes2[(HttpCodes2['RequestTimeout'] = 408)] = 'RequestTimeout';
+      HttpCodes2[(HttpCodes2['Conflict'] = 409)] = 'Conflict';
+      HttpCodes2[(HttpCodes2['Gone'] = 410)] = 'Gone';
+      HttpCodes2[(HttpCodes2['TooManyRequests'] = 429)] = 'TooManyRequests';
+      HttpCodes2[(HttpCodes2['InternalServerError'] = 500)] = 'InternalServerError';
+      HttpCodes2[(HttpCodes2['NotImplemented'] = 501)] = 'NotImplemented';
+      HttpCodes2[(HttpCodes2['BadGateway'] = 502)] = 'BadGateway';
+      HttpCodes2[(HttpCodes2['ServiceUnavailable'] = 503)] = 'ServiceUnavailable';
+      HttpCodes2[(HttpCodes2['GatewayTimeout'] = 504)] = 'GatewayTimeout';
+    })((HttpCodes = exports2.HttpCodes || (exports2.HttpCodes = {})));
+    var Headers;
+    (function (Headers2) {
+      Headers2['Accept'] = 'accept';
+      Headers2['ContentType'] = 'content-type';
+    })((Headers = exports2.Headers || (exports2.Headers = {})));
+    var MediaTypes;
+    (function (MediaTypes2) {
+      MediaTypes2['ApplicationJson'] = 'application/json';
+    })((MediaTypes = exports2.MediaTypes || (exports2.MediaTypes = {})));
+    function getProxyUrl(serverUrl) {
+      let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
+      return proxyUrl ? proxyUrl.href : '';
+    }
+    exports2.getProxyUrl = getProxyUrl;
+    var HttpRedirectCodes = [
+      HttpCodes.MovedPermanently,
+      HttpCodes.ResourceMoved,
+      HttpCodes.SeeOther,
+      HttpCodes.TemporaryRedirect,
+      HttpCodes.PermanentRedirect
+    ];
+    var HttpResponseRetryCodes = [
+      HttpCodes.BadGateway,
+      HttpCodes.ServiceUnavailable,
+      HttpCodes.GatewayTimeout
+    ];
+    var RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
+    var ExponentialBackoffCeiling = 10;
+    var ExponentialBackoffTimeSlice = 5;
+    var HttpClientError = class extends Error {
+      constructor(message, statusCode) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.statusCode = statusCode;
+        Object.setPrototypeOf(this, HttpClientError.prototype);
+      }
+    };
+    exports2.HttpClientError = HttpClientError;
+    var HttpClientResponse = class {
+      constructor(message) {
+        this.message = message;
+      }
+      readBody() {
+        return new Promise(async (resolve, reject) => {
+          let output = Buffer.alloc(0);
+          this.message.on('data', chunk => {
+            output = Buffer.concat([output, chunk]);
+          });
+          this.message.on('end', () => {
+            resolve(output.toString());
+          });
+        });
+      }
+    };
+    exports2.HttpClientResponse = HttpClientResponse;
+    function isHttps(requestUrl) {
+      let parsedUrl = new URL(requestUrl);
+      return parsedUrl.protocol === 'https:';
+    }
+    exports2.isHttps = isHttps;
+    var HttpClient = class {
+      constructor(userAgent, handlers, requestOptions) {
+        this._ignoreSslError = false;
+        this._allowRedirects = true;
+        this._allowRedirectDowngrade = false;
+        this._maxRedirects = 50;
+        this._allowRetries = false;
+        this._maxRetries = 1;
+        this._keepAlive = false;
+        this._disposed = false;
+        this.userAgent = userAgent;
+        this.handlers = handlers || [];
+        this.requestOptions = requestOptions;
+        if (requestOptions) {
+          if (requestOptions.ignoreSslError != null) {
+            this._ignoreSslError = requestOptions.ignoreSslError;
+          }
+          this._socketTimeout = requestOptions.socketTimeout;
+          if (requestOptions.allowRedirects != null) {
+            this._allowRedirects = requestOptions.allowRedirects;
+          }
+          if (requestOptions.allowRedirectDowngrade != null) {
+            this._allowRedirectDowngrade = requestOptions.allowRedirectDowngrade;
+          }
+          if (requestOptions.maxRedirects != null) {
+            this._maxRedirects = Math.max(requestOptions.maxRedirects, 0);
+          }
+          if (requestOptions.keepAlive != null) {
+            this._keepAlive = requestOptions.keepAlive;
+          }
+          if (requestOptions.allowRetries != null) {
+            this._allowRetries = requestOptions.allowRetries;
+          }
+          if (requestOptions.maxRetries != null) {
+            this._maxRetries = requestOptions.maxRetries;
+          }
+        }
+      }
+      options(requestUrl, additionalHeaders) {
+        return this.request('OPTIONS', requestUrl, null, additionalHeaders || {});
+      }
+      get(requestUrl, additionalHeaders) {
+        return this.request('GET', requestUrl, null, additionalHeaders || {});
+      }
+      del(requestUrl, additionalHeaders) {
+        return this.request('DELETE', requestUrl, null, additionalHeaders || {});
+      }
+      post(requestUrl, data, additionalHeaders) {
+        return this.request('POST', requestUrl, data, additionalHeaders || {});
+      }
+      patch(requestUrl, data, additionalHeaders) {
+        return this.request('PATCH', requestUrl, data, additionalHeaders || {});
+      }
+      put(requestUrl, data, additionalHeaders) {
+        return this.request('PUT', requestUrl, data, additionalHeaders || {});
+      }
+      head(requestUrl, additionalHeaders) {
+        return this.request('HEAD', requestUrl, null, additionalHeaders || {});
+      }
+      sendStream(verb, requestUrl, stream, additionalHeaders) {
+        return this.request(verb, requestUrl, stream, additionalHeaders);
+      }
+      async getJson(requestUrl, additionalHeaders = {}) {
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.Accept,
+          MediaTypes.ApplicationJson
+        );
+        let res = await this.get(requestUrl, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+      }
+      async postJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.Accept,
+          MediaTypes.ApplicationJson
+        );
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.ContentType,
+          MediaTypes.ApplicationJson
+        );
+        let res = await this.post(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+      }
+      async putJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.Accept,
+          MediaTypes.ApplicationJson
+        );
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.ContentType,
+          MediaTypes.ApplicationJson
+        );
+        let res = await this.put(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+      }
+      async patchJson(requestUrl, obj, additionalHeaders = {}) {
+        let data = JSON.stringify(obj, null, 2);
+        additionalHeaders[Headers.Accept] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.Accept,
+          MediaTypes.ApplicationJson
+        );
+        additionalHeaders[Headers.ContentType] = this._getExistingOrDefaultHeader(
+          additionalHeaders,
+          Headers.ContentType,
+          MediaTypes.ApplicationJson
+        );
+        let res = await this.patch(requestUrl, data, additionalHeaders);
+        return this._processResponse(res, this.requestOptions);
+      }
+      async request(verb, requestUrl, data, headers) {
+        if (this._disposed) {
+          throw new Error('Client has already been disposed.');
+        }
+        let parsedUrl = new URL(requestUrl);
+        let info = this._prepareRequest(verb, parsedUrl, headers);
+        let maxTries =
+          this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1 ? this._maxRetries + 1 : 1;
+        let numTries = 0;
+        let response;
+        while (numTries < maxTries) {
+          response = await this.requestRaw(info, data);
+          if (
+            response &&
+            response.message &&
+            response.message.statusCode === HttpCodes.Unauthorized
+          ) {
+            let authenticationHandler;
+            for (let i = 0; i < this.handlers.length; i++) {
+              if (this.handlers[i].canHandleAuthentication(response)) {
+                authenticationHandler = this.handlers[i];
+                break;
+              }
+            }
+            if (authenticationHandler) {
+              return authenticationHandler.handleAuthentication(this, info, data);
+            } else {
+              return response;
+            }
+          }
+          let redirectsRemaining = this._maxRedirects;
+          while (
+            HttpRedirectCodes.indexOf(response.message.statusCode) != -1 &&
+            this._allowRedirects &&
+            redirectsRemaining > 0
+          ) {
+            const redirectUrl = response.message.headers['location'];
+            if (!redirectUrl) {
+              break;
+            }
+            let parsedRedirectUrl = new URL(redirectUrl);
+            if (
+              parsedUrl.protocol == 'https:' &&
+              parsedUrl.protocol != parsedRedirectUrl.protocol &&
+              !this._allowRedirectDowngrade
+            ) {
+              throw new Error(
+                'Redirect from HTTPS to HTTP protocol. This downgrade is not allowed for security reasons. If you want to allow this behavior, set the allowRedirectDowngrade option to true.'
+              );
+            }
+            await response.readBody();
+            if (parsedRedirectUrl.hostname !== parsedUrl.hostname) {
+              for (let header in headers) {
+                if (header.toLowerCase() === 'authorization') {
+                  delete headers[header];
+                }
+              }
+            }
+            info = this._prepareRequest(verb, parsedRedirectUrl, headers);
+            response = await this.requestRaw(info, data);
+            redirectsRemaining--;
+          }
+          if (HttpResponseRetryCodes.indexOf(response.message.statusCode) == -1) {
+            return response;
+          }
+          numTries += 1;
+          if (numTries < maxTries) {
+            await response.readBody();
+            await this._performExponentialBackoff(numTries);
+          }
+        }
+        return response;
+      }
+      dispose() {
+        if (this._agent) {
+          this._agent.destroy();
+        }
+        this._disposed = true;
+      }
+      requestRaw(info, data) {
+        return new Promise((resolve, reject) => {
+          let callbackForResult = function (err, res) {
+            if (err) {
+              reject(err);
+            }
+            resolve(res);
+          };
+          this.requestRawWithCallback(info, data, callbackForResult);
+        });
+      }
+      requestRawWithCallback(info, data, onResult) {
+        let socket;
+        if (typeof data === 'string') {
+          info.options.headers['Content-Length'] = Buffer.byteLength(data, 'utf8');
+        }
+        let callbackCalled = false;
+        let handleResult = (err, res) => {
+          if (!callbackCalled) {
+            callbackCalled = true;
+            onResult(err, res);
+          }
+        };
+        let req = info.httpModule.request(info.options, msg => {
+          let res = new HttpClientResponse(msg);
+          handleResult(null, res);
+        });
+        req.on('socket', sock => {
+          socket = sock;
+        });
+        req.setTimeout(this._socketTimeout || 3 * 6e4, () => {
+          if (socket) {
+            socket.end();
+          }
+          handleResult(new Error('Request timeout: ' + info.options.path), null);
+        });
+        req.on('error', function (err) {
+          handleResult(err, null);
+        });
+        if (data && typeof data === 'string') {
+          req.write(data, 'utf8');
+        }
+        if (data && typeof data !== 'string') {
+          data.on('close', function () {
+            req.end();
+          });
+          data.pipe(req);
+        } else {
+          req.end();
+        }
+      }
+      getAgent(serverUrl) {
+        let parsedUrl = new URL(serverUrl);
+        return this._getAgent(parsedUrl);
+      }
+      _prepareRequest(method, requestUrl, headers) {
+        const info = {};
+        info.parsedUrl = requestUrl;
+        const usingSsl = info.parsedUrl.protocol === 'https:';
+        info.httpModule = usingSsl ? https : http;
+        const defaultPort = usingSsl ? 443 : 80;
+        info.options = {};
+        info.options.host = info.parsedUrl.hostname;
+        info.options.port = info.parsedUrl.port ? parseInt(info.parsedUrl.port) : defaultPort;
+        info.options.path = (info.parsedUrl.pathname || '') + (info.parsedUrl.search || '');
+        info.options.method = method;
+        info.options.headers = this._mergeHeaders(headers);
+        if (this.userAgent != null) {
+          info.options.headers['user-agent'] = this.userAgent;
+        }
+        info.options.agent = this._getAgent(info.parsedUrl);
+        if (this.handlers) {
+          this.handlers.forEach(handler => {
+            handler.prepareRequest(info.options);
+          });
+        }
+        return info;
+      }
+      _mergeHeaders(headers) {
+        const lowercaseKeys = obj =>
+          Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        if (this.requestOptions && this.requestOptions.headers) {
+          return Object.assign(
+            {},
+            lowercaseKeys(this.requestOptions.headers),
+            lowercaseKeys(headers)
+          );
+        }
+        return lowercaseKeys(headers || {});
+      }
+      _getExistingOrDefaultHeader(additionalHeaders, header, _default) {
+        const lowercaseKeys = obj =>
+          Object.keys(obj).reduce((c, k) => ((c[k.toLowerCase()] = obj[k]), c), {});
+        let clientHeader;
+        if (this.requestOptions && this.requestOptions.headers) {
+          clientHeader = lowercaseKeys(this.requestOptions.headers)[header];
+        }
+        return additionalHeaders[header] || clientHeader || _default;
+      }
+      _getAgent(parsedUrl) {
+        let agent;
+        let proxyUrl = pm.getProxyUrl(parsedUrl);
+        let useProxy = proxyUrl && proxyUrl.hostname;
+        if (this._keepAlive && useProxy) {
+          agent = this._proxyAgent;
+        }
+        if (this._keepAlive && !useProxy) {
+          agent = this._agent;
+        }
+        if (!!agent) {
+          return agent;
+        }
+        const usingSsl = parsedUrl.protocol === 'https:';
+        let maxSockets = 100;
+        if (!!this.requestOptions) {
+          maxSockets = this.requestOptions.maxSockets || http.globalAgent.maxSockets;
+        }
+        if (useProxy) {
+          if (!tunnel) {
+            tunnel = require_tunnel2();
+          }
+          const agentOptions = {
+            maxSockets,
+            keepAlive: this._keepAlive,
+            proxy: {
+              ...((proxyUrl.username || proxyUrl.password) && {
+                proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
+              }),
+              host: proxyUrl.hostname,
+              port: proxyUrl.port
+            }
+          };
+          let tunnelAgent;
+          const overHttps = proxyUrl.protocol === 'https:';
+          if (usingSsl) {
+            tunnelAgent = overHttps ? tunnel.httpsOverHttps : tunnel.httpsOverHttp;
+          } else {
+            tunnelAgent = overHttps ? tunnel.httpOverHttps : tunnel.httpOverHttp;
+          }
+          agent = tunnelAgent(agentOptions);
+          this._proxyAgent = agent;
+        }
+        if (this._keepAlive && !agent) {
+          const options = { keepAlive: this._keepAlive, maxSockets };
+          agent = usingSsl ? new https.Agent(options) : new http.Agent(options);
+          this._agent = agent;
+        }
+        if (!agent) {
+          agent = usingSsl ? https.globalAgent : http.globalAgent;
+        }
+        if (usingSsl && this._ignoreSslError) {
+          agent.options = Object.assign(agent.options || {}, {
+            rejectUnauthorized: false
+          });
+        }
+        return agent;
+      }
+      _performExponentialBackoff(retryNumber) {
+        retryNumber = Math.min(ExponentialBackoffCeiling, retryNumber);
+        const ms = ExponentialBackoffTimeSlice * Math.pow(2, retryNumber);
+        return new Promise(resolve => setTimeout(() => resolve(), ms));
+      }
+      static dateTimeDeserializer(key, value) {
+        if (typeof value === 'string') {
+          let a = new Date(value);
+          if (!isNaN(a.valueOf())) {
+            return a;
+          }
+        }
+        return value;
+      }
+      async _processResponse(res, options) {
+        return new Promise(async (resolve, reject) => {
+          const statusCode = res.message.statusCode;
+          const response = {
+            statusCode,
+            result: null,
+            headers: {}
+          };
+          if (statusCode == HttpCodes.NotFound) {
+            resolve(response);
+          }
+          let obj;
+          let contents;
+          try {
+            contents = await res.readBody();
+            if (contents && contents.length > 0) {
+              if (options && options.deserializeDates) {
+                obj = JSON.parse(contents, HttpClient.dateTimeDeserializer);
+              } else {
+                obj = JSON.parse(contents);
+              }
+              response.result = obj;
+            }
+            response.headers = res.message.headers;
+          } catch (err) {}
+          if (statusCode > 299) {
+            let msg;
+            if (obj && obj.message) {
+              msg = obj.message;
+            } else if (contents && contents.length > 0) {
+              msg = contents;
+            } else {
+              msg = 'Failed request: (' + statusCode + ')';
+            }
+            let err = new HttpClientError(msg, statusCode);
+            err.result = response.result;
+            reject(err);
+          } else {
+            resolve(response);
+          }
+        });
+      }
+    };
+    exports2.HttpClient = HttpClient;
+  }
+});
+
 // node_modules/@actions/github/lib/internal/utils.js
 var require_utils2 = __commonJS({
   'node_modules/@actions/github/lib/internal/utils.js'(exports2) {
@@ -2543,7 +3112,7 @@ var require_utils2 = __commonJS({
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
     exports2.getApiBaseUrl = exports2.getProxyAgent = exports2.getAuthString = void 0;
-    var httpClient = __importStar(require_lib());
+    var httpClient = __importStar(require_http_client());
     function getAuthString(token2, options) {
       if (!token2 && !options.auth) {
         throw new Error('Parameter token or opts.auth is required');
@@ -14522,7 +15091,7 @@ var require_dist_node5 = __commonJS({
     var isPlainObject = require_is_plain_object();
     var nodeFetch = _interopDefault(require_lib3());
     var requestError = require_dist_node4();
-    var VERSION = '5.6.3';
+    var VERSION = '5.6.1';
     function getBufferResponse(response) {
       return response.arrayBuffer();
     }
@@ -14795,21 +15364,9 @@ var require_dist_node7 = __commonJS({
   'node_modules/@octokit/auth-token/dist-node/index.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
-    var REGEX_IS_INSTALLATION_LEGACY = /^v1\./;
-    var REGEX_IS_INSTALLATION = /^ghs_/;
-    var REGEX_IS_USER_TO_SERVER = /^ghu_/;
     async function auth(token2) {
-      const isApp = token2.split(/\./).length === 3;
-      const isInstallation =
-        REGEX_IS_INSTALLATION_LEGACY.test(token2) || REGEX_IS_INSTALLATION.test(token2);
-      const isUserToServer = REGEX_IS_USER_TO_SERVER.test(token2);
-      const tokenType = isApp
-        ? 'app'
-        : isInstallation
-        ? 'installation'
-        : isUserToServer
-        ? 'user-to-server'
-        : 'oauth';
+      const tokenType =
+        token2.split(/\./).length === 3 ? 'app' : /^v\d+\./.test(token2) ? 'installation' : 'oauth';
       return {
         type: 'token',
         token: token2,
@@ -14880,7 +15437,7 @@ var require_dist_node8 = __commonJS({
       }
       return target;
     }
-    var VERSION = '3.6.0';
+    var VERSION = '3.5.1';
     var _excluded = ['authStrategy'];
     var Octokit = class {
       constructor(options = {}) {
@@ -15047,12 +15604,6 @@ var require_dist_node9 = __commonJS({
     }
     var Endpoints = {
       actions: {
-        addCustomLabelsToSelfHostedRunnerForOrg: [
-          'POST /orgs/{org}/actions/runners/{runner_id}/labels'
-        ],
-        addCustomLabelsToSelfHostedRunnerForRepo: [
-          'POST /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
-        ],
         addSelectedRepoToOrgSecret: [
           'PUT /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}'
         ],
@@ -15072,8 +15623,6 @@ var require_dist_node9 = __commonJS({
         createWorkflowDispatch: [
           'POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches'
         ],
-        deleteActionsCacheById: ['DELETE /repos/{owner}/{repo}/actions/caches/{cache_id}'],
-        deleteActionsCacheByKey: ['DELETE /repos/{owner}/{repo}/actions/caches{?key,ref}'],
         deleteArtifact: ['DELETE /repos/{owner}/{repo}/actions/artifacts/{artifact_id}'],
         deleteEnvironmentSecret: [
           'DELETE /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}'
@@ -15094,19 +15643,11 @@ var require_dist_node9 = __commonJS({
           'GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}'
         ],
         downloadJobLogsForWorkflowRun: ['GET /repos/{owner}/{repo}/actions/jobs/{job_id}/logs'],
-        downloadWorkflowRunAttemptLogs: [
-          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/logs'
-        ],
         downloadWorkflowRunLogs: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/logs'],
         enableSelectedRepositoryGithubActionsOrganization: [
           'PUT /orgs/{org}/actions/permissions/repositories/{repository_id}'
         ],
         enableWorkflow: ['PUT /repos/{owner}/{repo}/actions/workflows/{workflow_id}/enable'],
-        getActionsCacheList: ['GET /repos/{owner}/{repo}/actions/caches'],
-        getActionsCacheUsage: ['GET /repos/{owner}/{repo}/actions/cache/usage'],
-        getActionsCacheUsageByRepoForOrg: ['GET /orgs/{org}/actions/cache/usage-by-repository'],
-        getActionsCacheUsageForEnterprise: ['GET /enterprises/{enterprise}/actions/cache/usage'],
-        getActionsCacheUsageForOrg: ['GET /orgs/{org}/actions/cache/usage'],
         getAllowedActionsOrganization: ['GET /orgs/{org}/actions/permissions/selected-actions'],
         getAllowedActionsRepository: [
           'GET /repos/{owner}/{repo}/actions/permissions/selected-actions'
@@ -15117,15 +15658,6 @@ var require_dist_node9 = __commonJS({
         ],
         getEnvironmentSecret: [
           'GET /repositories/{repository_id}/environments/{environment_name}/secrets/{secret_name}'
-        ],
-        getGithubActionsDefaultWorkflowPermissionsEnterprise: [
-          'GET /enterprises/{enterprise}/actions/permissions/workflow'
-        ],
-        getGithubActionsDefaultWorkflowPermissionsOrganization: [
-          'GET /orgs/{org}/actions/permissions/workflow'
-        ],
-        getGithubActionsDefaultWorkflowPermissionsRepository: [
-          'GET /repos/{owner}/{repo}/actions/permissions/workflow'
         ],
         getGithubActionsPermissionsOrganization: ['GET /orgs/{org}/actions/permissions'],
         getGithubActionsPermissionsRepository: ['GET /repos/{owner}/{repo}/actions/permissions'],
@@ -15148,11 +15680,7 @@ var require_dist_node9 = __commonJS({
         getSelfHostedRunnerForOrg: ['GET /orgs/{org}/actions/runners/{runner_id}'],
         getSelfHostedRunnerForRepo: ['GET /repos/{owner}/{repo}/actions/runners/{runner_id}'],
         getWorkflow: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}'],
-        getWorkflowAccessToRepository: ['GET /repos/{owner}/{repo}/actions/permissions/access'],
         getWorkflowRun: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}'],
-        getWorkflowRunAttempt: [
-          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}'
-        ],
         getWorkflowRunUsage: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/timing'],
         getWorkflowUsage: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/timing'],
         listArtifactsForRepo: ['GET /repos/{owner}/{repo}/actions/artifacts'],
@@ -15160,13 +15688,6 @@ var require_dist_node9 = __commonJS({
           'GET /repositories/{repository_id}/environments/{environment_name}/secrets'
         ],
         listJobsForWorkflowRun: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs'],
-        listJobsForWorkflowRunAttempt: [
-          'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs'
-        ],
-        listLabelsForSelfHostedRunnerForOrg: ['GET /orgs/{org}/actions/runners/{runner_id}/labels'],
-        listLabelsForSelfHostedRunnerForRepo: [
-          'GET /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
-        ],
         listOrgSecrets: ['GET /orgs/{org}/actions/secrets'],
         listRepoSecrets: ['GET /repos/{owner}/{repo}/actions/secrets'],
         listRepoWorkflows: ['GET /repos/{owner}/{repo}/actions/workflows'],
@@ -15183,23 +15704,7 @@ var require_dist_node9 = __commonJS({
         listWorkflowRunArtifacts: ['GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts'],
         listWorkflowRuns: ['GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs'],
         listWorkflowRunsForRepo: ['GET /repos/{owner}/{repo}/actions/runs'],
-        reRunJobForWorkflowRun: ['POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun'],
         reRunWorkflow: ['POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun'],
-        reRunWorkflowFailedJobs: [
-          'POST /repos/{owner}/{repo}/actions/runs/{run_id}/rerun-failed-jobs'
-        ],
-        removeAllCustomLabelsFromSelfHostedRunnerForOrg: [
-          'DELETE /orgs/{org}/actions/runners/{runner_id}/labels'
-        ],
-        removeAllCustomLabelsFromSelfHostedRunnerForRepo: [
-          'DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
-        ],
-        removeCustomLabelFromSelfHostedRunnerForOrg: [
-          'DELETE /orgs/{org}/actions/runners/{runner_id}/labels/{name}'
-        ],
-        removeCustomLabelFromSelfHostedRunnerForRepo: [
-          'DELETE /repos/{owner}/{repo}/actions/runners/{runner_id}/labels/{name}'
-        ],
         removeSelectedRepoFromOrgSecret: [
           'DELETE /orgs/{org}/actions/secrets/{secret_name}/repositories/{repository_id}'
         ],
@@ -15210,21 +15715,6 @@ var require_dist_node9 = __commonJS({
         setAllowedActionsRepository: [
           'PUT /repos/{owner}/{repo}/actions/permissions/selected-actions'
         ],
-        setCustomLabelsForSelfHostedRunnerForOrg: [
-          'PUT /orgs/{org}/actions/runners/{runner_id}/labels'
-        ],
-        setCustomLabelsForSelfHostedRunnerForRepo: [
-          'PUT /repos/{owner}/{repo}/actions/runners/{runner_id}/labels'
-        ],
-        setGithubActionsDefaultWorkflowPermissionsEnterprise: [
-          'PUT /enterprises/{enterprise}/actions/permissions/workflow'
-        ],
-        setGithubActionsDefaultWorkflowPermissionsOrganization: [
-          'PUT /orgs/{org}/actions/permissions/workflow'
-        ],
-        setGithubActionsDefaultWorkflowPermissionsRepository: [
-          'PUT /repos/{owner}/{repo}/actions/permissions/workflow'
-        ],
         setGithubActionsPermissionsOrganization: ['PUT /orgs/{org}/actions/permissions'],
         setGithubActionsPermissionsRepository: ['PUT /repos/{owner}/{repo}/actions/permissions'],
         setSelectedReposForOrgSecret: [
@@ -15232,8 +15722,7 @@ var require_dist_node9 = __commonJS({
         ],
         setSelectedRepositoriesEnabledGithubActionsOrganization: [
           'PUT /orgs/{org}/actions/permissions/repositories'
-        ],
-        setWorkflowAccessToRepository: ['PUT /repos/{owner}/{repo}/actions/permissions/access']
+        ]
       },
       activity: {
         checkRepoIsStarredByAuthenticatedUser: ['GET /user/starred/{owner}/{repo}'],
@@ -15272,16 +15761,25 @@ var require_dist_node9 = __commonJS({
       },
       apps: {
         addRepoToInstallation: [
-          'PUT /user/installations/{installation_id}/repositories/{repository_id}',
-          {},
-          {
-            renamed: ['apps', 'addRepoToInstallationForAuthenticatedUser']
-          }
-        ],
-        addRepoToInstallationForAuthenticatedUser: [
           'PUT /user/installations/{installation_id}/repositories/{repository_id}'
         ],
         checkToken: ['POST /applications/{client_id}/token'],
+        createContentAttachment: [
+          'POST /content_references/{content_reference_id}/attachments',
+          {
+            mediaType: {
+              previews: ['corsair']
+            }
+          }
+        ],
+        createContentAttachmentForRepo: [
+          'POST /repos/{owner}/{repo}/content_references/{content_reference_id}/attachments',
+          {
+            mediaType: {
+              previews: ['corsair']
+            }
+          }
+        ],
         createFromManifest: ['POST /app-manifests/{code}/conversions'],
         createInstallationAccessToken: ['POST /app/installations/{installation_id}/access_tokens'],
         deleteAuthorization: ['DELETE /applications/{client_id}/grant'],
@@ -15314,13 +15812,6 @@ var require_dist_node9 = __commonJS({
         listWebhookDeliveries: ['GET /app/hook/deliveries'],
         redeliverWebhookDelivery: ['POST /app/hook/deliveries/{delivery_id}/attempts'],
         removeRepoFromInstallation: [
-          'DELETE /user/installations/{installation_id}/repositories/{repository_id}',
-          {},
-          {
-            renamed: ['apps', 'removeRepoFromInstallationForAuthenticatedUser']
-          }
-        ],
-        removeRepoFromInstallationForAuthenticatedUser: [
           'DELETE /user/installations/{installation_id}/repositories/{repository_id}'
         ],
         resetToken: ['PATCH /applications/{client_id}/token'],
@@ -15333,10 +15824,6 @@ var require_dist_node9 = __commonJS({
       billing: {
         getGithubActionsBillingOrg: ['GET /orgs/{org}/settings/billing/actions'],
         getGithubActionsBillingUser: ['GET /users/{username}/settings/billing/actions'],
-        getGithubAdvancedSecurityBillingGhe: [
-          'GET /enterprises/{enterprise}/settings/billing/advanced-security'
-        ],
-        getGithubAdvancedSecurityBillingOrg: ['GET /orgs/{org}/settings/billing/advanced-security'],
         getGithubPackagesBillingOrg: ['GET /orgs/{org}/settings/billing/packages'],
         getGithubPackagesBillingUser: ['GET /users/{username}/settings/billing/packages'],
         getSharedStorageBillingOrg: ['GET /orgs/{org}/settings/billing/shared-storage'],
@@ -15351,7 +15838,6 @@ var require_dist_node9 = __commonJS({
         listForRef: ['GET /repos/{owner}/{repo}/commits/{ref}/check-runs'],
         listForSuite: ['GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs'],
         listSuitesForRef: ['GET /repos/{owner}/{repo}/commits/{ref}/check-suites'],
-        rerequestRun: ['POST /repos/{owner}/{repo}/check-runs/{check_run_id}/rerequest'],
         rerequestSuite: ['POST /repos/{owner}/{repo}/check-suites/{check_suite_id}/rerequest'],
         setSuitesPreferences: ['PATCH /repos/{owner}/{repo}/check-suites/preferences'],
         update: ['PATCH /repos/{owner}/{repo}/check-runs/{check_run_id}']
@@ -15374,7 +15860,6 @@ var require_dist_node9 = __commonJS({
         listAlertInstances: [
           'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances'
         ],
-        listAlertsForOrg: ['GET /orgs/{org}/code-scanning/alerts'],
         listAlertsForRepo: ['GET /repos/{owner}/{repo}/code-scanning/alerts'],
         listAlertsInstances: [
           'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances',
@@ -15389,103 +15874,20 @@ var require_dist_node9 = __commonJS({
       },
       codesOfConduct: {
         getAllCodesOfConduct: ['GET /codes_of_conduct'],
-        getConductCode: ['GET /codes_of_conduct/{key}']
-      },
-      codespaces: {
-        addRepositoryForSecretForAuthenticatedUser: [
-          'PUT /user/codespaces/secrets/{secret_name}/repositories/{repository_id}'
-        ],
-        codespaceMachinesForAuthenticatedUser: ['GET /user/codespaces/{codespace_name}/machines'],
-        createForAuthenticatedUser: ['POST /user/codespaces'],
-        createOrUpdateRepoSecret: ['PUT /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
-        createOrUpdateSecretForAuthenticatedUser: ['PUT /user/codespaces/secrets/{secret_name}'],
-        createWithPrForAuthenticatedUser: [
-          'POST /repos/{owner}/{repo}/pulls/{pull_number}/codespaces'
-        ],
-        createWithRepoForAuthenticatedUser: ['POST /repos/{owner}/{repo}/codespaces'],
-        deleteForAuthenticatedUser: ['DELETE /user/codespaces/{codespace_name}'],
-        deleteFromOrganization: [
-          'DELETE /orgs/{org}/members/{username}/codespaces/{codespace_name}'
-        ],
-        deleteRepoSecret: ['DELETE /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
-        deleteSecretForAuthenticatedUser: ['DELETE /user/codespaces/secrets/{secret_name}'],
-        exportForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/exports'],
-        getExportDetailsForAuthenticatedUser: [
-          'GET /user/codespaces/{codespace_name}/exports/{export_id}'
-        ],
-        getForAuthenticatedUser: ['GET /user/codespaces/{codespace_name}'],
-        getPublicKeyForAuthenticatedUser: ['GET /user/codespaces/secrets/public-key'],
-        getRepoPublicKey: ['GET /repos/{owner}/{repo}/codespaces/secrets/public-key'],
-        getRepoSecret: ['GET /repos/{owner}/{repo}/codespaces/secrets/{secret_name}'],
-        getSecretForAuthenticatedUser: ['GET /user/codespaces/secrets/{secret_name}'],
-        listDevcontainersInRepositoryForAuthenticatedUser: [
-          'GET /repos/{owner}/{repo}/codespaces/devcontainers'
-        ],
-        listForAuthenticatedUser: ['GET /user/codespaces'],
-        listInOrganization: [
-          'GET /orgs/{org}/codespaces',
-          {},
+        getConductCode: ['GET /codes_of_conduct/{key}'],
+        getForRepo: [
+          'GET /repos/{owner}/{repo}/community/code_of_conduct',
           {
-            renamedParameters: {
-              org_id: 'org'
+            mediaType: {
+              previews: ['scarlet-witch']
             }
           }
-        ],
-        listInRepositoryForAuthenticatedUser: ['GET /repos/{owner}/{repo}/codespaces'],
-        listRepoSecrets: ['GET /repos/{owner}/{repo}/codespaces/secrets'],
-        listRepositoriesForSecretForAuthenticatedUser: [
-          'GET /user/codespaces/secrets/{secret_name}/repositories'
-        ],
-        listSecretsForAuthenticatedUser: ['GET /user/codespaces/secrets'],
-        removeRepositoryForSecretForAuthenticatedUser: [
-          'DELETE /user/codespaces/secrets/{secret_name}/repositories/{repository_id}'
-        ],
-        repoMachinesForAuthenticatedUser: ['GET /repos/{owner}/{repo}/codespaces/machines'],
-        setRepositoriesForSecretForAuthenticatedUser: [
-          'PUT /user/codespaces/secrets/{secret_name}/repositories'
-        ],
-        startForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/start'],
-        stopForAuthenticatedUser: ['POST /user/codespaces/{codespace_name}/stop'],
-        stopInOrganization: [
-          'POST /orgs/{org}/members/{username}/codespaces/{codespace_name}/stop'
-        ],
-        updateForAuthenticatedUser: ['PATCH /user/codespaces/{codespace_name}']
-      },
-      dependabot: {
-        addSelectedRepoToOrgSecret: [
-          'PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}'
-        ],
-        createOrUpdateOrgSecret: ['PUT /orgs/{org}/dependabot/secrets/{secret_name}'],
-        createOrUpdateRepoSecret: ['PUT /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
-        deleteOrgSecret: ['DELETE /orgs/{org}/dependabot/secrets/{secret_name}'],
-        deleteRepoSecret: ['DELETE /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
-        getOrgPublicKey: ['GET /orgs/{org}/dependabot/secrets/public-key'],
-        getOrgSecret: ['GET /orgs/{org}/dependabot/secrets/{secret_name}'],
-        getRepoPublicKey: ['GET /repos/{owner}/{repo}/dependabot/secrets/public-key'],
-        getRepoSecret: ['GET /repos/{owner}/{repo}/dependabot/secrets/{secret_name}'],
-        listOrgSecrets: ['GET /orgs/{org}/dependabot/secrets'],
-        listRepoSecrets: ['GET /repos/{owner}/{repo}/dependabot/secrets'],
-        listSelectedReposForOrgSecret: [
-          'GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories'
-        ],
-        removeSelectedRepoFromOrgSecret: [
-          'DELETE /orgs/{org}/dependabot/secrets/{secret_name}/repositories/{repository_id}'
-        ],
-        setSelectedReposForOrgSecret: [
-          'PUT /orgs/{org}/dependabot/secrets/{secret_name}/repositories'
         ]
-      },
-      dependencyGraph: {
-        createRepositorySnapshot: ['POST /repos/{owner}/{repo}/dependency-graph/snapshots'],
-        diffRange: ['GET /repos/{owner}/{repo}/dependency-graph/compare/{basehead}']
       },
       emojis: {
         get: ['GET /emojis']
       },
       enterpriseAdmin: {
-        addCustomLabelsToSelfHostedRunnerForEnterprise: [
-          'POST /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
-        ],
         disableSelectedOrganizationGithubActionsEnterprise: [
           'DELETE /enterprises/{enterprise}/actions/permissions/organizations/{org_id}'
         ],
@@ -15498,24 +15900,11 @@ var require_dist_node9 = __commonJS({
         getGithubActionsPermissionsEnterprise: [
           'GET /enterprises/{enterprise}/actions/permissions'
         ],
-        getServerStatistics: ['GET /enterprise-installation/{enterprise_or_org}/server-statistics'],
-        listLabelsForSelfHostedRunnerForEnterprise: [
-          'GET /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
-        ],
         listSelectedOrganizationsEnabledGithubActionsEnterprise: [
           'GET /enterprises/{enterprise}/actions/permissions/organizations'
         ],
-        removeAllCustomLabelsFromSelfHostedRunnerForEnterprise: [
-          'DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
-        ],
-        removeCustomLabelFromSelfHostedRunnerForEnterprise: [
-          'DELETE /enterprises/{enterprise}/actions/runners/{runner_id}/labels/{name}'
-        ],
         setAllowedActionsEnterprise: [
           'PUT /enterprises/{enterprise}/actions/permissions/selected-actions'
-        ],
-        setCustomLabelsForSelfHostedRunnerForEnterprise: [
-          'PUT /enterprises/{enterprise}/actions/runners/{runner_id}/labels'
         ],
         setGithubActionsPermissionsEnterprise: [
           'PUT /enterprises/{enterprise}/actions/permissions'
@@ -15619,7 +16008,14 @@ var require_dist_node9 = __commonJS({
         listCommentsForRepo: ['GET /repos/{owner}/{repo}/issues/comments'],
         listEvents: ['GET /repos/{owner}/{repo}/issues/{issue_number}/events'],
         listEventsForRepo: ['GET /repos/{owner}/{repo}/issues/events'],
-        listEventsForTimeline: ['GET /repos/{owner}/{repo}/issues/{issue_number}/timeline'],
+        listEventsForTimeline: [
+          'GET /repos/{owner}/{repo}/issues/{issue_number}/timeline',
+          {
+            mediaType: {
+              previews: ['mockingbird']
+            }
+          }
+        ],
         listForAuthenticatedUser: ['GET /user/issues'],
         listForOrg: ['GET /orgs/{org}/issues'],
         listForRepo: ['GET /repos/{owner}/{repo}/issues'],
@@ -15662,24 +16058,87 @@ var require_dist_node9 = __commonJS({
       },
       migrations: {
         cancelImport: ['DELETE /repos/{owner}/{repo}/import'],
-        deleteArchiveForAuthenticatedUser: ['DELETE /user/migrations/{migration_id}/archive'],
-        deleteArchiveForOrg: ['DELETE /orgs/{org}/migrations/{migration_id}/archive'],
-        downloadArchiveForOrg: ['GET /orgs/{org}/migrations/{migration_id}/archive'],
-        getArchiveForAuthenticatedUser: ['GET /user/migrations/{migration_id}/archive'],
+        deleteArchiveForAuthenticatedUser: [
+          'DELETE /user/migrations/{migration_id}/archive',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        deleteArchiveForOrg: [
+          'DELETE /orgs/{org}/migrations/{migration_id}/archive',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        downloadArchiveForOrg: [
+          'GET /orgs/{org}/migrations/{migration_id}/archive',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        getArchiveForAuthenticatedUser: [
+          'GET /user/migrations/{migration_id}/archive',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
         getCommitAuthors: ['GET /repos/{owner}/{repo}/import/authors'],
         getImportStatus: ['GET /repos/{owner}/{repo}/import'],
         getLargeFiles: ['GET /repos/{owner}/{repo}/import/large_files'],
-        getStatusForAuthenticatedUser: ['GET /user/migrations/{migration_id}'],
-        getStatusForOrg: ['GET /orgs/{org}/migrations/{migration_id}'],
-        listForAuthenticatedUser: ['GET /user/migrations'],
-        listForOrg: ['GET /orgs/{org}/migrations'],
-        listReposForAuthenticatedUser: ['GET /user/migrations/{migration_id}/repositories'],
-        listReposForOrg: ['GET /orgs/{org}/migrations/{migration_id}/repositories'],
+        getStatusForAuthenticatedUser: [
+          'GET /user/migrations/{migration_id}',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        getStatusForOrg: [
+          'GET /orgs/{org}/migrations/{migration_id}',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        listForAuthenticatedUser: [
+          'GET /user/migrations',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        listForOrg: [
+          'GET /orgs/{org}/migrations',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
+        listReposForOrg: [
+          'GET /orgs/{org}/migrations/{migration_id}/repositories',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
         listReposForUser: [
           'GET /user/migrations/{migration_id}/repositories',
-          {},
           {
-            renamed: ['migrations', 'listReposForAuthenticatedUser']
+            mediaType: {
+              previews: ['wyandotte']
+            }
           }
         ],
         mapCommitAuthor: ['PATCH /repos/{owner}/{repo}/import/authors/{author_id}'],
@@ -15688,9 +16147,21 @@ var require_dist_node9 = __commonJS({
         startForOrg: ['POST /orgs/{org}/migrations'],
         startImport: ['PUT /repos/{owner}/{repo}/import'],
         unlockRepoForAuthenticatedUser: [
-          'DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock'
+          'DELETE /user/migrations/{migration_id}/repos/{repo_name}/lock',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
         ],
-        unlockRepoForOrg: ['DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock'],
+        unlockRepoForOrg: [
+          'DELETE /orgs/{org}/migrations/{migration_id}/repos/{repo_name}/lock',
+          {
+            mediaType: {
+              previews: ['wyandotte']
+            }
+          }
+        ],
         updateImport: ['PATCH /repos/{owner}/{repo}/import']
       },
       orgs: {
@@ -15712,7 +16183,6 @@ var require_dist_node9 = __commonJS({
         list: ['GET /organizations'],
         listAppInstallations: ['GET /orgs/{org}/installations'],
         listBlockedUsers: ['GET /orgs/{org}/blocks'],
-        listCustomRoles: ['GET /organizations/{organization_id}/custom_roles'],
         listFailedInvitations: ['GET /orgs/{org}/failed_invitations'],
         listForAuthenticatedUser: ['GET /user/orgs'],
         listForUser: ['GET /users/{username}/orgs'],
@@ -15792,7 +16262,7 @@ var require_dist_node9 = __commonJS({
         ],
         listPackagesForAuthenticatedUser: ['GET /user/packages'],
         listPackagesForOrganization: ['GET /orgs/{org}/packages'],
-        listPackagesForUser: ['GET /users/{username}/packages'],
+        listPackagesForUser: ['GET /user/{username}/packages'],
         restorePackageForAuthenticatedUser: [
           'POST /user/packages/{package_type}/{package_name}/restore{?token}'
         ],
@@ -15813,31 +16283,206 @@ var require_dist_node9 = __commonJS({
         ]
       },
       projects: {
-        addCollaborator: ['PUT /projects/{project_id}/collaborators/{username}'],
-        createCard: ['POST /projects/columns/{column_id}/cards'],
-        createColumn: ['POST /projects/{project_id}/columns'],
-        createForAuthenticatedUser: ['POST /user/projects'],
-        createForOrg: ['POST /orgs/{org}/projects'],
-        createForRepo: ['POST /repos/{owner}/{repo}/projects'],
-        delete: ['DELETE /projects/{project_id}'],
-        deleteCard: ['DELETE /projects/columns/cards/{card_id}'],
-        deleteColumn: ['DELETE /projects/columns/{column_id}'],
-        get: ['GET /projects/{project_id}'],
-        getCard: ['GET /projects/columns/cards/{card_id}'],
-        getColumn: ['GET /projects/columns/{column_id}'],
-        getPermissionForUser: ['GET /projects/{project_id}/collaborators/{username}/permission'],
-        listCards: ['GET /projects/columns/{column_id}/cards'],
-        listCollaborators: ['GET /projects/{project_id}/collaborators'],
-        listColumns: ['GET /projects/{project_id}/columns'],
-        listForOrg: ['GET /orgs/{org}/projects'],
-        listForRepo: ['GET /repos/{owner}/{repo}/projects'],
-        listForUser: ['GET /users/{username}/projects'],
-        moveCard: ['POST /projects/columns/cards/{card_id}/moves'],
-        moveColumn: ['POST /projects/columns/{column_id}/moves'],
-        removeCollaborator: ['DELETE /projects/{project_id}/collaborators/{username}'],
-        update: ['PATCH /projects/{project_id}'],
-        updateCard: ['PATCH /projects/columns/cards/{card_id}'],
-        updateColumn: ['PATCH /projects/columns/{column_id}']
+        addCollaborator: [
+          'PUT /projects/{project_id}/collaborators/{username}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        createCard: [
+          'POST /projects/columns/{column_id}/cards',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        createColumn: [
+          'POST /projects/{project_id}/columns',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        createForAuthenticatedUser: [
+          'POST /user/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        createForOrg: [
+          'POST /orgs/{org}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        createForRepo: [
+          'POST /repos/{owner}/{repo}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        delete: [
+          'DELETE /projects/{project_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        deleteCard: [
+          'DELETE /projects/columns/cards/{card_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        deleteColumn: [
+          'DELETE /projects/columns/{column_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        get: [
+          'GET /projects/{project_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        getCard: [
+          'GET /projects/columns/cards/{card_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        getColumn: [
+          'GET /projects/columns/{column_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        getPermissionForUser: [
+          'GET /projects/{project_id}/collaborators/{username}/permission',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listCards: [
+          'GET /projects/columns/{column_id}/cards',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listCollaborators: [
+          'GET /projects/{project_id}/collaborators',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listColumns: [
+          'GET /projects/{project_id}/columns',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listForOrg: [
+          'GET /orgs/{org}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listForRepo: [
+          'GET /repos/{owner}/{repo}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        listForUser: [
+          'GET /users/{username}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        moveCard: [
+          'POST /projects/columns/cards/{card_id}/moves',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        moveColumn: [
+          'POST /projects/columns/{column_id}/moves',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        removeCollaborator: [
+          'DELETE /projects/{project_id}/collaborators/{username}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        update: [
+          'PATCH /projects/{project_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        updateCard: [
+          'PATCH /projects/columns/cards/{card_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
+        updateColumn: [
+          'PATCH /projects/columns/{column_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ]
       },
       pulls: {
         checkIfMerged: ['GET /repos/{owner}/{repo}/pulls/{pull_number}/merge'],
@@ -15876,7 +16521,14 @@ var require_dist_node9 = __commonJS({
         requestReviewers: ['POST /repos/{owner}/{repo}/pulls/{pull_number}/requested_reviewers'],
         submitReview: ['POST /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/events'],
         update: ['PATCH /repos/{owner}/{repo}/pulls/{pull_number}'],
-        updateBranch: ['PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch'],
+        updateBranch: [
+          'PUT /repos/{owner}/{repo}/pulls/{pull_number}/update-branch',
+          {
+            mediaType: {
+              previews: ['lydian']
+            }
+          }
+        ],
         updateReview: ['PUT /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}'],
         updateReviewComment: ['PATCH /repos/{owner}/{repo}/pulls/comments/{comment_id}']
       },
@@ -15884,67 +16536,173 @@ var require_dist_node9 = __commonJS({
         get: ['GET /rate_limit']
       },
       reactions: {
-        createForCommitComment: ['POST /repos/{owner}/{repo}/comments/{comment_id}/reactions'],
-        createForIssue: ['POST /repos/{owner}/{repo}/issues/{issue_number}/reactions'],
+        createForCommitComment: [
+          'POST /repos/{owner}/{repo}/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
+        createForIssue: [
+          'POST /repos/{owner}/{repo}/issues/{issue_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
         createForIssueComment: [
-          'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'
+          'POST /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         createForPullRequestReviewComment: [
-          'POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions'
+          'POST /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
-        createForRelease: ['POST /repos/{owner}/{repo}/releases/{release_id}/reactions'],
+        createForRelease: [
+          'POST /repos/{owner}/{repo}/releases/{release_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
         createForTeamDiscussionCommentInOrg: [
-          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions'
+          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         createForTeamDiscussionInOrg: [
-          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions'
+          'POST /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForCommitComment: [
-          'DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}'
+          'DELETE /repos/{owner}/{repo}/comments/{comment_id}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForIssue: [
-          'DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}'
+          'DELETE /repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForIssueComment: [
-          'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}'
+          'DELETE /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForPullRequestComment: [
-          'DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}'
-        ],
-        deleteForRelease: [
-          'DELETE /repos/{owner}/{repo}/releases/{release_id}/reactions/{reaction_id}'
+          'DELETE /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForTeamDiscussion: [
-          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}'
+          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         deleteForTeamDiscussionComment: [
-          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}'
+          'DELETE /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
-        listForCommitComment: ['GET /repos/{owner}/{repo}/comments/{comment_id}/reactions'],
-        listForIssue: ['GET /repos/{owner}/{repo}/issues/{issue_number}/reactions'],
-        listForIssueComment: ['GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions'],
+        deleteLegacy: [
+          'DELETE /reactions/{reaction_id}',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          },
+          {
+            deprecated:
+              'octokit.rest.reactions.deleteLegacy() is deprecated, see https://docs.github.com/rest/reference/reactions/#delete-a-reaction-legacy'
+          }
+        ],
+        listForCommitComment: [
+          'GET /repos/{owner}/{repo}/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
+        listForIssue: [
+          'GET /repos/{owner}/{repo}/issues/{issue_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
+        listForIssueComment: [
+          'GET /repos/{owner}/{repo}/issues/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
+        ],
         listForPullRequestReviewComment: [
-          'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions'
+          'GET /repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
-        listForRelease: ['GET /repos/{owner}/{repo}/releases/{release_id}/reactions'],
         listForTeamDiscussionCommentInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions'
+          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/comments/{comment_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ],
         listForTeamDiscussionInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions'
+          'GET /orgs/{org}/teams/{team_slug}/discussions/{discussion_number}/reactions',
+          {
+            mediaType: {
+              previews: ['squirrel-girl']
+            }
+          }
         ]
       },
       repos: {
-        acceptInvitation: [
-          'PATCH /user/repository_invitations/{invitation_id}',
-          {},
-          {
-            renamed: ['repos', 'acceptInvitationForAuthenticatedUser']
-          }
-        ],
-        acceptInvitationForAuthenticatedUser: [
-          'PATCH /user/repository_invitations/{invitation_id}'
-        ],
+        acceptInvitation: ['PATCH /user/repository_invitations/{invitation_id}'],
         addAppAccessRestrictions: [
           'POST /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps',
           {},
@@ -15975,14 +16733,25 @@ var require_dist_node9 = __commonJS({
           }
         ],
         checkCollaborator: ['GET /repos/{owner}/{repo}/collaborators/{username}'],
-        checkVulnerabilityAlerts: ['GET /repos/{owner}/{repo}/vulnerability-alerts'],
-        codeownersErrors: ['GET /repos/{owner}/{repo}/codeowners/errors'],
+        checkVulnerabilityAlerts: [
+          'GET /repos/{owner}/{repo}/vulnerability-alerts',
+          {
+            mediaType: {
+              previews: ['dorian']
+            }
+          }
+        ],
         compareCommits: ['GET /repos/{owner}/{repo}/compare/{base}...{head}'],
         compareCommitsWithBasehead: ['GET /repos/{owner}/{repo}/compare/{basehead}'],
         createAutolink: ['POST /repos/{owner}/{repo}/autolinks'],
         createCommitComment: ['POST /repos/{owner}/{repo}/commits/{commit_sha}/comments'],
         createCommitSignatureProtection: [
-          'POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
+          'POST /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
+          {
+            mediaType: {
+              previews: ['zzzax']
+            }
+          }
         ],
         createCommitStatus: ['POST /repos/{owner}/{repo}/statuses/{sha}'],
         createDeployKey: ['POST /repos/{owner}/{repo}/keys'],
@@ -15994,21 +16763,25 @@ var require_dist_node9 = __commonJS({
         createInOrg: ['POST /orgs/{org}/repos'],
         createOrUpdateEnvironment: ['PUT /repos/{owner}/{repo}/environments/{environment_name}'],
         createOrUpdateFileContents: ['PUT /repos/{owner}/{repo}/contents/{path}'],
-        createPagesSite: ['POST /repos/{owner}/{repo}/pages'],
-        createRelease: ['POST /repos/{owner}/{repo}/releases'],
-        createTagProtection: ['POST /repos/{owner}/{repo}/tags/protection'],
-        createUsingTemplate: ['POST /repos/{template_owner}/{template_repo}/generate'],
-        createWebhook: ['POST /repos/{owner}/{repo}/hooks'],
-        declineInvitation: [
-          'DELETE /user/repository_invitations/{invitation_id}',
-          {},
+        createPagesSite: [
+          'POST /repos/{owner}/{repo}/pages',
           {
-            renamed: ['repos', 'declineInvitationForAuthenticatedUser']
+            mediaType: {
+              previews: ['switcheroo']
+            }
           }
         ],
-        declineInvitationForAuthenticatedUser: [
-          'DELETE /user/repository_invitations/{invitation_id}'
+        createRelease: ['POST /repos/{owner}/{repo}/releases'],
+        createUsingTemplate: [
+          'POST /repos/{template_owner}/{template_repo}/generate',
+          {
+            mediaType: {
+              previews: ['baptiste']
+            }
+          }
         ],
+        createWebhook: ['POST /repos/{owner}/{repo}/hooks'],
+        declineInvitation: ['DELETE /user/repository_invitations/{invitation_id}'],
         delete: ['DELETE /repos/{owner}/{repo}'],
         deleteAccessRestrictions: [
           'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/restrictions'
@@ -16021,23 +16794,47 @@ var require_dist_node9 = __commonJS({
         deleteBranchProtection: ['DELETE /repos/{owner}/{repo}/branches/{branch}/protection'],
         deleteCommitComment: ['DELETE /repos/{owner}/{repo}/comments/{comment_id}'],
         deleteCommitSignatureProtection: [
-          'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
+          'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
+          {
+            mediaType: {
+              previews: ['zzzax']
+            }
+          }
         ],
         deleteDeployKey: ['DELETE /repos/{owner}/{repo}/keys/{key_id}'],
         deleteDeployment: ['DELETE /repos/{owner}/{repo}/deployments/{deployment_id}'],
         deleteFile: ['DELETE /repos/{owner}/{repo}/contents/{path}'],
         deleteInvitation: ['DELETE /repos/{owner}/{repo}/invitations/{invitation_id}'],
-        deletePagesSite: ['DELETE /repos/{owner}/{repo}/pages'],
+        deletePagesSite: [
+          'DELETE /repos/{owner}/{repo}/pages',
+          {
+            mediaType: {
+              previews: ['switcheroo']
+            }
+          }
+        ],
         deletePullRequestReviewProtection: [
           'DELETE /repos/{owner}/{repo}/branches/{branch}/protection/required_pull_request_reviews'
         ],
         deleteRelease: ['DELETE /repos/{owner}/{repo}/releases/{release_id}'],
         deleteReleaseAsset: ['DELETE /repos/{owner}/{repo}/releases/assets/{asset_id}'],
-        deleteTagProtection: ['DELETE /repos/{owner}/{repo}/tags/protection/{tag_protection_id}'],
         deleteWebhook: ['DELETE /repos/{owner}/{repo}/hooks/{hook_id}'],
-        disableAutomatedSecurityFixes: ['DELETE /repos/{owner}/{repo}/automated-security-fixes'],
-        disableLfsForRepo: ['DELETE /repos/{owner}/{repo}/lfs'],
-        disableVulnerabilityAlerts: ['DELETE /repos/{owner}/{repo}/vulnerability-alerts'],
+        disableAutomatedSecurityFixes: [
+          'DELETE /repos/{owner}/{repo}/automated-security-fixes',
+          {
+            mediaType: {
+              previews: ['london']
+            }
+          }
+        ],
+        disableVulnerabilityAlerts: [
+          'DELETE /repos/{owner}/{repo}/vulnerability-alerts',
+          {
+            mediaType: {
+              previews: ['dorian']
+            }
+          }
+        ],
         downloadArchive: [
           'GET /repos/{owner}/{repo}/zipball/{ref}',
           {},
@@ -16047,10 +16844,22 @@ var require_dist_node9 = __commonJS({
         ],
         downloadTarballArchive: ['GET /repos/{owner}/{repo}/tarball/{ref}'],
         downloadZipballArchive: ['GET /repos/{owner}/{repo}/zipball/{ref}'],
-        enableAutomatedSecurityFixes: ['PUT /repos/{owner}/{repo}/automated-security-fixes'],
-        enableLfsForRepo: ['PUT /repos/{owner}/{repo}/lfs'],
-        enableVulnerabilityAlerts: ['PUT /repos/{owner}/{repo}/vulnerability-alerts'],
-        generateReleaseNotes: ['POST /repos/{owner}/{repo}/releases/generate-notes'],
+        enableAutomatedSecurityFixes: [
+          'PUT /repos/{owner}/{repo}/automated-security-fixes',
+          {
+            mediaType: {
+              previews: ['london']
+            }
+          }
+        ],
+        enableVulnerabilityAlerts: [
+          'PUT /repos/{owner}/{repo}/vulnerability-alerts',
+          {
+            mediaType: {
+              previews: ['dorian']
+            }
+          }
+        ],
         get: ['GET /repos/{owner}/{repo}'],
         getAccessRestrictions: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions'
@@ -16062,7 +16871,14 @@ var require_dist_node9 = __commonJS({
         getAllStatusCheckContexts: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_status_checks/contexts'
         ],
-        getAllTopics: ['GET /repos/{owner}/{repo}/topics'],
+        getAllTopics: [
+          'GET /repos/{owner}/{repo}/topics',
+          {
+            mediaType: {
+              previews: ['mercy']
+            }
+          }
+        ],
         getAppsWithAccessToProtectedBranch: [
           'GET /repos/{owner}/{repo}/branches/{branch}/protection/restrictions/apps'
         ],
@@ -16079,7 +16895,12 @@ var require_dist_node9 = __commonJS({
         getCommitActivityStats: ['GET /repos/{owner}/{repo}/stats/commit_activity'],
         getCommitComment: ['GET /repos/{owner}/{repo}/comments/{comment_id}'],
         getCommitSignatureProtection: [
-          'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures'
+          'GET /repos/{owner}/{repo}/branches/{branch}/protection/required_signatures',
+          {
+            mediaType: {
+              previews: ['zzzax']
+            }
+          }
         ],
         getCommunityProfileMetrics: ['GET /repos/{owner}/{repo}/community/profile'],
         getContent: ['GET /repos/{owner}/{repo}/contents/{path}'],
@@ -16123,7 +16944,12 @@ var require_dist_node9 = __commonJS({
         listAutolinks: ['GET /repos/{owner}/{repo}/autolinks'],
         listBranches: ['GET /repos/{owner}/{repo}/branches'],
         listBranchesForHeadCommit: [
-          'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head'
+          'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head',
+          {
+            mediaType: {
+              previews: ['groot']
+            }
+          }
         ],
         listCollaborators: ['GET /repos/{owner}/{repo}/collaborators'],
         listCommentsForCommit: ['GET /repos/{owner}/{repo}/commits/{commit_sha}/comments'],
@@ -16144,11 +16970,15 @@ var require_dist_node9 = __commonJS({
         listPagesBuilds: ['GET /repos/{owner}/{repo}/pages/builds'],
         listPublic: ['GET /repositories'],
         listPullRequestsAssociatedWithCommit: [
-          'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls'
+          'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
+          {
+            mediaType: {
+              previews: ['groot']
+            }
+          }
         ],
         listReleaseAssets: ['GET /repos/{owner}/{repo}/releases/{release_id}/assets'],
         listReleases: ['GET /repos/{owner}/{repo}/releases'],
-        listTagProtection: ['GET /repos/{owner}/{repo}/tags/protection'],
         listTags: ['GET /repos/{owner}/{repo}/tags'],
         listTeams: ['GET /repos/{owner}/{repo}/teams'],
         listWebhookDeliveries: ['GET /repos/{owner}/{repo}/hooks/{hook_id}/deliveries'],
@@ -16192,7 +17022,14 @@ var require_dist_node9 = __commonJS({
           }
         ],
         renameBranch: ['POST /repos/{owner}/{repo}/branches/{branch}/rename'],
-        replaceAllTopics: ['PUT /repos/{owner}/{repo}/topics'],
+        replaceAllTopics: [
+          'PUT /repos/{owner}/{repo}/topics',
+          {
+            mediaType: {
+              previews: ['mercy']
+            }
+          }
+        ],
         requestPagesBuild: ['POST /repos/{owner}/{repo}/pages/builds'],
         setAdminBranchProtection: [
           'POST /repos/{owner}/{repo}/branches/{branch}/protection/enforce_admins'
@@ -16258,21 +17095,31 @@ var require_dist_node9 = __commonJS({
       },
       search: {
         code: ['GET /search/code'],
-        commits: ['GET /search/commits'],
+        commits: [
+          'GET /search/commits',
+          {
+            mediaType: {
+              previews: ['cloak']
+            }
+          }
+        ],
         issuesAndPullRequests: ['GET /search/issues'],
         labels: ['GET /search/labels'],
         repos: ['GET /search/repositories'],
-        topics: ['GET /search/topics'],
+        topics: [
+          'GET /search/topics',
+          {
+            mediaType: {
+              previews: ['mercy']
+            }
+          }
+        ],
         users: ['GET /search/users']
       },
       secretScanning: {
         getAlert: ['GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}'],
-        listAlertsForEnterprise: ['GET /enterprises/{enterprise}/secret-scanning/alerts'],
         listAlertsForOrg: ['GET /orgs/{org}/secret-scanning/alerts'],
         listAlertsForRepo: ['GET /repos/{owner}/{repo}/secret-scanning/alerts'],
-        listLocationsForAlert: [
-          'GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations'
-        ],
         updateAlert: ['PATCH /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}']
       },
       teams: {
@@ -16280,11 +17127,21 @@ var require_dist_node9 = __commonJS({
           'PUT /orgs/{org}/teams/{team_slug}/memberships/{username}'
         ],
         addOrUpdateProjectPermissionsInOrg: [
-          'PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}'
+          'PUT /orgs/{org}/teams/{team_slug}/projects/{project_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
         ],
         addOrUpdateRepoPermissionsInOrg: ['PUT /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}'],
         checkPermissionsForProjectInOrg: [
-          'GET /orgs/{org}/teams/{team_slug}/projects/{project_id}'
+          'GET /orgs/{org}/teams/{team_slug}/projects/{project_id}',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
         ],
         checkPermissionsForRepoInOrg: ['GET /orgs/{org}/teams/{team_slug}/repos/{owner}/{repo}'],
         create: ['POST /orgs/{org}/teams'],
@@ -16314,7 +17171,14 @@ var require_dist_node9 = __commonJS({
         listForAuthenticatedUser: ['GET /user/teams'],
         listMembersInOrg: ['GET /orgs/{org}/teams/{team_slug}/members'],
         listPendingInvitationsInOrg: ['GET /orgs/{org}/teams/{team_slug}/invitations'],
-        listProjectsInOrg: ['GET /orgs/{org}/teams/{team_slug}/projects'],
+        listProjectsInOrg: [
+          'GET /orgs/{org}/teams/{team_slug}/projects',
+          {
+            mediaType: {
+              previews: ['inertia']
+            }
+          }
+        ],
         listReposInOrg: ['GET /orgs/{org}/teams/{team_slug}/repos'],
         removeMembershipForUserInOrg: [
           'DELETE /orgs/{org}/teams/{team_slug}/memberships/{username}'
@@ -16330,146 +17194,41 @@ var require_dist_node9 = __commonJS({
         updateInOrg: ['PATCH /orgs/{org}/teams/{team_slug}']
       },
       users: {
-        addEmailForAuthenticated: [
-          'POST /user/emails',
-          {},
-          {
-            renamed: ['users', 'addEmailForAuthenticatedUser']
-          }
-        ],
-        addEmailForAuthenticatedUser: ['POST /user/emails'],
+        addEmailForAuthenticated: ['POST /user/emails'],
         block: ['PUT /user/blocks/{username}'],
         checkBlocked: ['GET /user/blocks/{username}'],
         checkFollowingForUser: ['GET /users/{username}/following/{target_user}'],
         checkPersonIsFollowedByAuthenticated: ['GET /user/following/{username}'],
-        createGpgKeyForAuthenticated: [
-          'POST /user/gpg_keys',
-          {},
-          {
-            renamed: ['users', 'createGpgKeyForAuthenticatedUser']
-          }
-        ],
-        createGpgKeyForAuthenticatedUser: ['POST /user/gpg_keys'],
-        createPublicSshKeyForAuthenticated: [
-          'POST /user/keys',
-          {},
-          {
-            renamed: ['users', 'createPublicSshKeyForAuthenticatedUser']
-          }
-        ],
-        createPublicSshKeyForAuthenticatedUser: ['POST /user/keys'],
-        deleteEmailForAuthenticated: [
-          'DELETE /user/emails',
-          {},
-          {
-            renamed: ['users', 'deleteEmailForAuthenticatedUser']
-          }
-        ],
-        deleteEmailForAuthenticatedUser: ['DELETE /user/emails'],
-        deleteGpgKeyForAuthenticated: [
-          'DELETE /user/gpg_keys/{gpg_key_id}',
-          {},
-          {
-            renamed: ['users', 'deleteGpgKeyForAuthenticatedUser']
-          }
-        ],
-        deleteGpgKeyForAuthenticatedUser: ['DELETE /user/gpg_keys/{gpg_key_id}'],
-        deletePublicSshKeyForAuthenticated: [
-          'DELETE /user/keys/{key_id}',
-          {},
-          {
-            renamed: ['users', 'deletePublicSshKeyForAuthenticatedUser']
-          }
-        ],
-        deletePublicSshKeyForAuthenticatedUser: ['DELETE /user/keys/{key_id}'],
+        createGpgKeyForAuthenticated: ['POST /user/gpg_keys'],
+        createPublicSshKeyForAuthenticated: ['POST /user/keys'],
+        deleteEmailForAuthenticated: ['DELETE /user/emails'],
+        deleteGpgKeyForAuthenticated: ['DELETE /user/gpg_keys/{gpg_key_id}'],
+        deletePublicSshKeyForAuthenticated: ['DELETE /user/keys/{key_id}'],
         follow: ['PUT /user/following/{username}'],
         getAuthenticated: ['GET /user'],
         getByUsername: ['GET /users/{username}'],
         getContextForUser: ['GET /users/{username}/hovercard'],
-        getGpgKeyForAuthenticated: [
-          'GET /user/gpg_keys/{gpg_key_id}',
-          {},
-          {
-            renamed: ['users', 'getGpgKeyForAuthenticatedUser']
-          }
-        ],
-        getGpgKeyForAuthenticatedUser: ['GET /user/gpg_keys/{gpg_key_id}'],
-        getPublicSshKeyForAuthenticated: [
-          'GET /user/keys/{key_id}',
-          {},
-          {
-            renamed: ['users', 'getPublicSshKeyForAuthenticatedUser']
-          }
-        ],
-        getPublicSshKeyForAuthenticatedUser: ['GET /user/keys/{key_id}'],
+        getGpgKeyForAuthenticated: ['GET /user/gpg_keys/{gpg_key_id}'],
+        getPublicSshKeyForAuthenticated: ['GET /user/keys/{key_id}'],
         list: ['GET /users'],
-        listBlockedByAuthenticated: [
-          'GET /user/blocks',
-          {},
-          {
-            renamed: ['users', 'listBlockedByAuthenticatedUser']
-          }
-        ],
-        listBlockedByAuthenticatedUser: ['GET /user/blocks'],
-        listEmailsForAuthenticated: [
-          'GET /user/emails',
-          {},
-          {
-            renamed: ['users', 'listEmailsForAuthenticatedUser']
-          }
-        ],
-        listEmailsForAuthenticatedUser: ['GET /user/emails'],
-        listFollowedByAuthenticated: [
-          'GET /user/following',
-          {},
-          {
-            renamed: ['users', 'listFollowedByAuthenticatedUser']
-          }
-        ],
-        listFollowedByAuthenticatedUser: ['GET /user/following'],
+        listBlockedByAuthenticated: ['GET /user/blocks'],
+        listEmailsForAuthenticated: ['GET /user/emails'],
+        listFollowedByAuthenticated: ['GET /user/following'],
         listFollowersForAuthenticatedUser: ['GET /user/followers'],
         listFollowersForUser: ['GET /users/{username}/followers'],
         listFollowingForUser: ['GET /users/{username}/following'],
-        listGpgKeysForAuthenticated: [
-          'GET /user/gpg_keys',
-          {},
-          {
-            renamed: ['users', 'listGpgKeysForAuthenticatedUser']
-          }
-        ],
-        listGpgKeysForAuthenticatedUser: ['GET /user/gpg_keys'],
+        listGpgKeysForAuthenticated: ['GET /user/gpg_keys'],
         listGpgKeysForUser: ['GET /users/{username}/gpg_keys'],
-        listPublicEmailsForAuthenticated: [
-          'GET /user/public_emails',
-          {},
-          {
-            renamed: ['users', 'listPublicEmailsForAuthenticatedUser']
-          }
-        ],
-        listPublicEmailsForAuthenticatedUser: ['GET /user/public_emails'],
+        listPublicEmailsForAuthenticated: ['GET /user/public_emails'],
         listPublicKeysForUser: ['GET /users/{username}/keys'],
-        listPublicSshKeysForAuthenticated: [
-          'GET /user/keys',
-          {},
-          {
-            renamed: ['users', 'listPublicSshKeysForAuthenticatedUser']
-          }
-        ],
-        listPublicSshKeysForAuthenticatedUser: ['GET /user/keys'],
-        setPrimaryEmailVisibilityForAuthenticated: [
-          'PATCH /user/email/visibility',
-          {},
-          {
-            renamed: ['users', 'setPrimaryEmailVisibilityForAuthenticatedUser']
-          }
-        ],
-        setPrimaryEmailVisibilityForAuthenticatedUser: ['PATCH /user/email/visibility'],
+        listPublicSshKeysForAuthenticated: ['GET /user/keys'],
+        setPrimaryEmailVisibilityForAuthenticated: ['PATCH /user/email/visibility'],
         unblock: ['DELETE /user/blocks/{username}'],
         unfollow: ['DELETE /user/following/{username}'],
         updateAuthenticated: ['PATCH /user']
       }
     };
-    var VERSION = '5.16.2';
+    var VERSION = '5.10.0';
     function endpointsToMethods(octokit, endpointsMap) {
       const newMethods = {};
       for (const [scope, endpoints] of Object.entries(endpointsMap)) {
@@ -16569,31 +17328,34 @@ var require_dist_node10 = __commonJS({
   'node_modules/@octokit/plugin-paginate-rest/dist-node/index.js'(exports2) {
     'use strict';
     Object.defineProperty(exports2, '__esModule', { value: true });
-    var VERSION = '2.21.3';
+    var VERSION = '2.16.0';
     function ownKeys(object, enumerableOnly) {
       var keys = Object.keys(object);
       if (Object.getOwnPropertySymbols) {
         var symbols = Object.getOwnPropertySymbols(object);
-        enumerableOnly &&
-          (symbols = symbols.filter(function (sym) {
+        if (enumerableOnly) {
+          symbols = symbols.filter(function (sym) {
             return Object.getOwnPropertyDescriptor(object, sym).enumerable;
-          })),
-          keys.push.apply(keys, symbols);
+          });
+        }
+        keys.push.apply(keys, symbols);
       }
       return keys;
     }
     function _objectSpread2(target) {
       for (var i = 1; i < arguments.length; i++) {
         var source = arguments[i] != null ? arguments[i] : {};
-        i % 2
-          ? ownKeys(Object(source), true).forEach(function (key) {
-              _defineProperty(target, key, source[key]);
-            })
-          : Object.getOwnPropertyDescriptors
-          ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source))
-          : ownKeys(Object(source)).forEach(function (key) {
-              Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
-            });
+        if (i % 2) {
+          ownKeys(Object(source), true).forEach(function (key) {
+            _defineProperty(target, key, source[key]);
+          });
+        } else if (Object.getOwnPropertyDescriptors) {
+          Object.defineProperties(target, Object.getOwnPropertyDescriptors(source));
+        } else {
+          ownKeys(Object(source)).forEach(function (key) {
+            Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key));
+          });
+        }
       }
       return target;
     }
@@ -16725,9 +17487,7 @@ var require_dist_node10 = __commonJS({
       'GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/organizations',
       'GET /enterprises/{enterprise}/actions/runner-groups/{runner_group_id}/runners',
       'GET /enterprises/{enterprise}/actions/runners',
-      'GET /enterprises/{enterprise}/audit-log',
-      'GET /enterprises/{enterprise}/secret-scanning/alerts',
-      'GET /enterprises/{enterprise}/settings/billing/advanced-security',
+      'GET /enterprises/{enterprise}/actions/runners/downloads',
       'GET /events',
       'GET /gists',
       'GET /gists/public',
@@ -16737,7 +17497,6 @@ var require_dist_node10 = __commonJS({
       'GET /gists/{gist_id}/forks',
       'GET /installation/repositories',
       'GET /issues',
-      'GET /licenses',
       'GET /marketplace_listing/plans',
       'GET /marketplace_listing/plans/{plan_id}/accounts',
       'GET /marketplace_listing/stubbed/plans',
@@ -16745,23 +17504,17 @@ var require_dist_node10 = __commonJS({
       'GET /networks/{owner}/{repo}/events',
       'GET /notifications',
       'GET /organizations',
-      'GET /orgs/{org}/actions/cache/usage-by-repository',
       'GET /orgs/{org}/actions/permissions/repositories',
       'GET /orgs/{org}/actions/runner-groups',
       'GET /orgs/{org}/actions/runner-groups/{runner_group_id}/repositories',
       'GET /orgs/{org}/actions/runner-groups/{runner_group_id}/runners',
       'GET /orgs/{org}/actions/runners',
+      'GET /orgs/{org}/actions/runners/downloads',
       'GET /orgs/{org}/actions/secrets',
       'GET /orgs/{org}/actions/secrets/{secret_name}/repositories',
-      'GET /orgs/{org}/audit-log',
       'GET /orgs/{org}/blocks',
-      'GET /orgs/{org}/code-scanning/alerts',
-      'GET /orgs/{org}/codespaces',
       'GET /orgs/{org}/credential-authorizations',
-      'GET /orgs/{org}/dependabot/secrets',
-      'GET /orgs/{org}/dependabot/secrets/{secret_name}/repositories',
       'GET /orgs/{org}/events',
-      'GET /orgs/{org}/external-groups',
       'GET /orgs/{org}/failed_invitations',
       'GET /orgs/{org}/hooks',
       'GET /orgs/{org}/hooks/{hook_id}/deliveries',
@@ -16774,12 +17527,10 @@ var require_dist_node10 = __commonJS({
       'GET /orgs/{org}/migrations/{migration_id}/repositories',
       'GET /orgs/{org}/outside_collaborators',
       'GET /orgs/{org}/packages',
-      'GET /orgs/{org}/packages/{package_type}/{package_name}/versions',
       'GET /orgs/{org}/projects',
       'GET /orgs/{org}/public_members',
       'GET /orgs/{org}/repos',
       'GET /orgs/{org}/secret-scanning/alerts',
-      'GET /orgs/{org}/settings/billing/advanced-security',
       'GET /orgs/{org}/team-sync/groups',
       'GET /orgs/{org}/teams',
       'GET /orgs/{org}/teams/{team_slug}/discussions',
@@ -16790,45 +17541,41 @@ var require_dist_node10 = __commonJS({
       'GET /orgs/{org}/teams/{team_slug}/members',
       'GET /orgs/{org}/teams/{team_slug}/projects',
       'GET /orgs/{org}/teams/{team_slug}/repos',
+      'GET /orgs/{org}/teams/{team_slug}/team-sync/group-mappings',
       'GET /orgs/{org}/teams/{team_slug}/teams',
       'GET /projects/columns/{column_id}/cards',
       'GET /projects/{project_id}/collaborators',
       'GET /projects/{project_id}/columns',
       'GET /repos/{owner}/{repo}/actions/artifacts',
-      'GET /repos/{owner}/{repo}/actions/caches',
       'GET /repos/{owner}/{repo}/actions/runners',
+      'GET /repos/{owner}/{repo}/actions/runners/downloads',
       'GET /repos/{owner}/{repo}/actions/runs',
       'GET /repos/{owner}/{repo}/actions/runs/{run_id}/artifacts',
-      'GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs',
       'GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs',
       'GET /repos/{owner}/{repo}/actions/secrets',
       'GET /repos/{owner}/{repo}/actions/workflows',
       'GET /repos/{owner}/{repo}/actions/workflows/{workflow_id}/runs',
       'GET /repos/{owner}/{repo}/assignees',
+      'GET /repos/{owner}/{repo}/autolinks',
       'GET /repos/{owner}/{repo}/branches',
       'GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations',
       'GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs',
       'GET /repos/{owner}/{repo}/code-scanning/alerts',
       'GET /repos/{owner}/{repo}/code-scanning/alerts/{alert_number}/instances',
       'GET /repos/{owner}/{repo}/code-scanning/analyses',
-      'GET /repos/{owner}/{repo}/codespaces',
-      'GET /repos/{owner}/{repo}/codespaces/devcontainers',
-      'GET /repos/{owner}/{repo}/codespaces/secrets',
       'GET /repos/{owner}/{repo}/collaborators',
       'GET /repos/{owner}/{repo}/comments',
       'GET /repos/{owner}/{repo}/comments/{comment_id}/reactions',
       'GET /repos/{owner}/{repo}/commits',
+      'GET /repos/{owner}/{repo}/commits/{commit_sha}/branches-where-head',
       'GET /repos/{owner}/{repo}/commits/{commit_sha}/comments',
       'GET /repos/{owner}/{repo}/commits/{commit_sha}/pulls',
       'GET /repos/{owner}/{repo}/commits/{ref}/check-runs',
       'GET /repos/{owner}/{repo}/commits/{ref}/check-suites',
-      'GET /repos/{owner}/{repo}/commits/{ref}/status',
       'GET /repos/{owner}/{repo}/commits/{ref}/statuses',
       'GET /repos/{owner}/{repo}/contributors',
-      'GET /repos/{owner}/{repo}/dependabot/secrets',
       'GET /repos/{owner}/{repo}/deployments',
       'GET /repos/{owner}/{repo}/deployments/{deployment_id}/statuses',
-      'GET /repos/{owner}/{repo}/environments',
       'GET /repos/{owner}/{repo}/events',
       'GET /repos/{owner}/{repo}/forks',
       'GET /repos/{owner}/{repo}/git/matching-refs/{ref}',
@@ -16862,16 +17609,16 @@ var require_dist_node10 = __commonJS({
       'GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments',
       'GET /repos/{owner}/{repo}/releases',
       'GET /repos/{owner}/{repo}/releases/{release_id}/assets',
-      'GET /repos/{owner}/{repo}/releases/{release_id}/reactions',
       'GET /repos/{owner}/{repo}/secret-scanning/alerts',
-      'GET /repos/{owner}/{repo}/secret-scanning/alerts/{alert_number}/locations',
       'GET /repos/{owner}/{repo}/stargazers',
       'GET /repos/{owner}/{repo}/subscribers',
       'GET /repos/{owner}/{repo}/tags',
       'GET /repos/{owner}/{repo}/teams',
-      'GET /repos/{owner}/{repo}/topics',
       'GET /repositories',
       'GET /repositories/{repository_id}/environments/{environment_name}/secrets',
+      'GET /scim/v2/enterprises/{enterprise}/Groups',
+      'GET /scim/v2/enterprises/{enterprise}/Users',
+      'GET /scim/v2/organizations/{org}/Users',
       'GET /search/code',
       'GET /search/commits',
       'GET /search/issues',
@@ -16887,10 +17634,9 @@ var require_dist_node10 = __commonJS({
       'GET /teams/{team_id}/members',
       'GET /teams/{team_id}/projects',
       'GET /teams/{team_id}/repos',
+      'GET /teams/{team_id}/team-sync/group-mappings',
       'GET /teams/{team_id}/teams',
       'GET /user/blocks',
-      'GET /user/codespaces',
-      'GET /user/codespaces/secrets',
       'GET /user/emails',
       'GET /user/followers',
       'GET /user/following',
@@ -16906,13 +17652,13 @@ var require_dist_node10 = __commonJS({
       'GET /user/migrations/{migration_id}/repositories',
       'GET /user/orgs',
       'GET /user/packages',
-      'GET /user/packages/{package_type}/{package_name}/versions',
       'GET /user/public_emails',
       'GET /user/repos',
       'GET /user/repository_invitations',
       'GET /user/starred',
       'GET /user/subscriptions',
       'GET /user/teams',
+      'GET /user/{username}/packages',
       'GET /users',
       'GET /users/{username}/events',
       'GET /users/{username}/events/orgs/{org}',
@@ -16923,7 +17669,6 @@ var require_dist_node10 = __commonJS({
       'GET /users/{username}/gpg_keys',
       'GET /users/{username}/keys',
       'GET /users/{username}/orgs',
-      'GET /users/{username}/packages',
       'GET /users/{username}/projects',
       'GET /users/{username}/received_events',
       'GET /users/{username}/received_events/public',
@@ -16996,7 +17741,7 @@ var require_utils4 = __commonJS({
         return result;
       };
     Object.defineProperty(exports2, '__esModule', { value: true });
-    exports2.getOctokitOptions = exports2.GitHub = exports2.defaults = exports2.context = void 0;
+    exports2.getOctokitOptions = exports2.GitHub = exports2.context = void 0;
     var Context = __importStar(require_context());
     var Utils = __importStar(require_utils2());
     var core_1 = require_dist_node8();
@@ -17004,7 +17749,7 @@ var require_utils4 = __commonJS({
     var plugin_paginate_rest_1 = require_dist_node10();
     exports2.context = new Context.Context();
     var baseUrl = Utils.getApiBaseUrl();
-    exports2.defaults = {
+    var defaults = {
       baseUrl,
       request: {
         agent: Utils.getProxyAgent(baseUrl)
@@ -17013,7 +17758,7 @@ var require_utils4 = __commonJS({
     exports2.GitHub = core_1.Octokit.plugin(
       plugin_rest_endpoint_methods_1.restEndpointMethods,
       plugin_paginate_rest_1.paginateRest
-    ).defaults(exports2.defaults);
+    ).defaults(defaults);
     function getOctokitOptions(token2, options) {
       const opts = Object.assign({}, options || {});
       const auth = Utils.getAuthString(token2, opts);
@@ -17073,9 +17818,8 @@ var require_github = __commonJS({
     var Context = __importStar(require_context());
     var utils_1 = require_utils4();
     exports2.context = new Context.Context();
-    function getOctokit(token2, options, ...additionalPlugins) {
-      const GitHubWithPlugins = utils_1.GitHub.plugin(...additionalPlugins);
-      return new GitHubWithPlugins(utils_1.getOctokitOptions(token2, options));
+    function getOctokit(token2, options) {
+      return new utils_1.GitHub(utils_1.getOctokitOptions(token2, options));
     }
     exports2.getOctokit = getOctokit;
   }
@@ -17222,7 +17966,7 @@ var require_re = __commonJS({
     var R = 0;
     var createToken = (name, value, isGlobal) => {
       const index = R++;
-      debug(name, index, value);
+      debug(index, value);
       t[name] = index;
       src[index] = value;
       re[index] = new RegExp(value, isGlobal ? 'g' : void 0);
@@ -17313,8 +18057,8 @@ var require_re = __commonJS({
       `^\\s*(${src[t.XRANGEPLAINLOOSE]})\\s+-\\s+(${src[t.XRANGEPLAINLOOSE]})\\s*$`
     );
     createToken('STAR', '(<|>)?=?\\s*\\*');
-    createToken('GTE0', '^\\s*>=\\s*0\\.0\\.0\\s*$');
-    createToken('GTE0PRE', '^\\s*>=\\s*0\\.0\\.0-0\\s*$');
+    createToken('GTE0', '^\\s*>=\\s*0.0.0\\s*$');
+    createToken('GTE0PRE', '^\\s*>=\\s*0.0.0-0\\s*$');
   }
 });
 
@@ -17329,9 +18073,9 @@ var require_parse_options = __commonJS({
         ? { loose: true }
         : opts
             .filter(k => options[k])
-            .reduce((o, k) => {
-              o[k] = true;
-              return o;
+            .reduce((options2, k) => {
+              options2[k] = true;
+              return options2;
             }, {});
     module2.exports = parseOptions;
   }
@@ -17568,7 +18312,7 @@ var require_semver = __commonJS({
               }
             }
             if (identifier) {
-              if (compareIdentifiers(this.prerelease[0], identifier) === 0) {
+              if (this.prerelease[0] === identifier) {
                 if (isNaN(this.prerelease[1])) {
                   this.prerelease = [identifier, 0];
                 }
@@ -17655,10 +18399,7 @@ var require_inc = __commonJS({
         options = void 0;
       }
       try {
-        return new SemVer(version instanceof SemVer ? version.version : version, options).inc(
-          release,
-          identifier
-        ).version;
+        return new SemVer(version, options).inc(release, identifier).version;
       } catch (er) {
         return null;
       }
@@ -17858,20 +18599,12 @@ var require_cmp = __commonJS({
     var cmp = (a, op, b, loose) => {
       switch (op) {
         case '===':
-          if (typeof a === 'object') {
-            a = a.version;
-          }
-          if (typeof b === 'object') {
-            b = b.version;
-          }
+          if (typeof a === 'object') a = a.version;
+          if (typeof b === 'object') b = b.version;
           return a === b;
         case '!==':
-          if (typeof a === 'object') {
-            a = a.version;
-          }
-          if (typeof b === 'object') {
-            b = b.version;
-          }
+          if (typeof a === 'object') a = a.version;
+          if (typeof b === 'object') b = b.version;
           return a !== b;
         case '':
         case '=':
@@ -17928,9 +18661,7 @@ var require_coerce = __commonJS({
         }
         re[t.COERCERTL].lastIndex = -1;
       }
-      if (match === null) {
-        return null;
-      }
+      if (match === null) return null;
       return parse(`${match[2]}.${match[3] || '0'}.${match[4] || '0'}`, options);
     };
     module2.exports = coerce;
@@ -18607,8 +19338,8 @@ var require_range = __commonJS({
         this.includePrerelease = !!options.includePrerelease;
         this.raw = range;
         this.set = range
-          .split('||')
-          .map(r => this.parseRange(r.trim()))
+          .split(/\s*\|\|\s*/)
+          .map(range2 => this.parseRange(range2.trim()))
           .filter(c => c.length);
         if (!this.set.length) {
           throw new TypeError(`Invalid SemVer Range: ${range}`);
@@ -18616,9 +19347,8 @@ var require_range = __commonJS({
         if (this.set.length > 1) {
           const first = this.set[0];
           this.set = this.set.filter(c => !isNullSet(c[0]));
-          if (this.set.length === 0) {
-            this.set = [first];
-          } else if (this.set.length > 1) {
+          if (this.set.length === 0) this.set = [first];
+          else if (this.set.length > 1) {
             for (const c of this.set) {
               if (c.length === 1 && isAny(c[0])) {
                 this.set = [c];
@@ -18646,42 +19376,32 @@ var require_range = __commonJS({
         const memoOpts = Object.keys(this.options).join(',');
         const memoKey = `parseRange:${memoOpts}:${range}`;
         const cached = cache.get(memoKey);
-        if (cached) {
-          return cached;
-        }
+        if (cached) return cached;
         const loose = this.options.loose;
         const hr = loose ? re[t.HYPHENRANGELOOSE] : re[t.HYPHENRANGE];
         range = range.replace(hr, hyphenReplace(this.options.includePrerelease));
         debug('hyphen replace', range);
         range = range.replace(re[t.COMPARATORTRIM], comparatorTrimReplace);
-        debug('comparator trim', range);
+        debug('comparator trim', range, re[t.COMPARATORTRIM]);
         range = range.replace(re[t.TILDETRIM], tildeTrimReplace);
         range = range.replace(re[t.CARETTRIM], caretTrimReplace);
         range = range.split(/\s+/).join(' ');
-        let rangeList = range
+        const compRe = loose ? re[t.COMPARATORLOOSE] : re[t.COMPARATOR];
+        const rangeList = range
           .split(' ')
           .map(comp => parseComparator(comp, this.options))
           .join(' ')
           .split(/\s+/)
-          .map(comp => replaceGTE0(comp, this.options));
-        if (loose) {
-          rangeList = rangeList.filter(comp => {
-            debug('loose invalid filter', comp, this.options);
-            return !!comp.match(re[t.COMPARATORLOOSE]);
-          });
-        }
-        debug('range list', rangeList);
+          .map(comp => replaceGTE0(comp, this.options))
+          .filter(this.options.loose ? comp => !!comp.match(compRe) : () => true)
+          .map(comp => new Comparator(comp, this.options));
+        const l = rangeList.length;
         const rangeMap = new Map();
-        const comparators = rangeList.map(comp => new Comparator(comp, this.options));
-        for (const comp of comparators) {
-          if (isNullSet(comp)) {
-            return [comp];
-          }
+        for (const comp of rangeList) {
+          if (isNullSet(comp)) return [comp];
           rangeMap.set(comp.value, comp);
         }
-        if (rangeMap.size > 1 && rangeMap.has('')) {
-          rangeMap.delete('');
-        }
+        if (rangeMap.size > 1 && rangeMap.has('')) rangeMap.delete('');
         const result = [...rangeMap.values()];
         cache.set(memoKey, result);
         return result;
@@ -18764,8 +19484,8 @@ var require_range = __commonJS({
       comp
         .trim()
         .split(/\s+/)
-        .map(c => {
-          return replaceTilde(c, options);
+        .map(comp2 => {
+          return replaceTilde(comp2, options);
         })
         .join(' ');
     var replaceTilde = (comp, options) => {
@@ -18793,8 +19513,8 @@ var require_range = __commonJS({
       comp
         .trim()
         .split(/\s+/)
-        .map(c => {
-          return replaceCaret(c, options);
+        .map(comp2 => {
+          return replaceCaret(comp2, options);
         })
         .join(' ');
     var replaceCaret = (comp, options) => {
@@ -18845,8 +19565,8 @@ var require_range = __commonJS({
       debug('replaceXRanges', comp, options);
       return comp
         .split(/\s+/)
-        .map(c => {
-          return replaceXRange(c, options);
+        .map(comp2 => {
+          return replaceXRange(comp2, options);
         })
         .join(' ');
     };
@@ -18892,9 +19612,7 @@ var require_range = __commonJS({
               m = +m + 1;
             }
           }
-          if (gtlt === '<') {
-            pr = '-0';
-          }
+          if (gtlt === '<') pr = '-0';
           ret = `${gtlt + M}.${m}.${p}${pr}`;
         } else if (xm) {
           ret = `>=${M}.0.0${pr} <${+M + 1}.0.0-0`;
@@ -19220,9 +19938,7 @@ var require_min_version = __commonJS({
               throw new Error(`Unexpected operation: ${comparator.operator}`);
           }
         });
-        if (setMin && (!minver || gt(minver, setMin))) {
-          minver = setMin;
-        }
+        if (setMin && (!minver || gt(minver, setMin))) minver = setMin;
       }
       if (minver && range.test(minver)) {
         return minver;
@@ -19354,40 +20070,30 @@ var require_simplify = __commonJS({
     var compare = require_compare();
     module2.exports = (versions, range, options) => {
       const set = [];
-      let first = null;
+      let min = null;
       let prev = null;
       const v = versions.sort((a, b) => compare(a, b, options));
       for (const version of v) {
         const included = satisfies(version, range, options);
         if (included) {
           prev = version;
-          if (!first) {
-            first = version;
-          }
+          if (!min) min = version;
         } else {
           if (prev) {
-            set.push([first, prev]);
+            set.push([min, prev]);
           }
           prev = null;
-          first = null;
+          min = null;
         }
       }
-      if (first) {
-        set.push([first, null]);
-      }
+      if (min) set.push([min, null]);
       const ranges = [];
-      for (const [min, max] of set) {
-        if (min === max) {
-          ranges.push(min);
-        } else if (!max && min === v[0]) {
-          ranges.push('*');
-        } else if (!max) {
-          ranges.push(`>=${min}`);
-        } else if (min === v[0]) {
-          ranges.push(`<=${max}`);
-        } else {
-          ranges.push(`${min} - ${max}`);
-        }
+      for (const [min2, max] of set) {
+        if (min2 === max) ranges.push(min2);
+        else if (!max && min2 === v[0]) ranges.push('*');
+        else if (!max) ranges.push(`>=${min2}`);
+        else if (min2 === v[0]) ranges.push(`<=${max}`);
+        else ranges.push(`${min2} - ${max}`);
       }
       const simplified = ranges.join(' || ');
       const original = typeof range.raw === 'string' ? range.raw : String(range);
@@ -19405,9 +20111,7 @@ var require_subset = __commonJS({
     var satisfies = require_satisfies();
     var compare = require_compare();
     var subset = (sub, dom, options = {}) => {
-      if (sub === dom) {
-        return true;
-      }
+      if (sub === dom) return true;
       sub = new Range(sub, options);
       dom = new Range(dom, options);
       let sawNonNull = false;
@@ -19415,70 +20119,42 @@ var require_subset = __commonJS({
         for (const simpleDom of dom.set) {
           const isSub = simpleSubset(simpleSub, simpleDom, options);
           sawNonNull = sawNonNull || isSub !== null;
-          if (isSub) {
-            continue OUTER;
-          }
+          if (isSub) continue OUTER;
         }
-        if (sawNonNull) {
-          return false;
-        }
+        if (sawNonNull) return false;
       }
       return true;
     };
     var simpleSubset = (sub, dom, options) => {
-      if (sub === dom) {
-        return true;
-      }
+      if (sub === dom) return true;
       if (sub.length === 1 && sub[0].semver === ANY) {
-        if (dom.length === 1 && dom[0].semver === ANY) {
-          return true;
-        } else if (options.includePrerelease) {
-          sub = [new Comparator('>=0.0.0-0')];
-        } else {
-          sub = [new Comparator('>=0.0.0')];
-        }
+        if (dom.length === 1 && dom[0].semver === ANY) return true;
+        else if (options.includePrerelease) sub = [new Comparator('>=0.0.0-0')];
+        else sub = [new Comparator('>=0.0.0')];
       }
       if (dom.length === 1 && dom[0].semver === ANY) {
-        if (options.includePrerelease) {
-          return true;
-        } else {
-          dom = [new Comparator('>=0.0.0')];
-        }
+        if (options.includePrerelease) return true;
+        else dom = [new Comparator('>=0.0.0')];
       }
       const eqSet = new Set();
       let gt, lt;
       for (const c of sub) {
-        if (c.operator === '>' || c.operator === '>=') {
-          gt = higherGT(gt, c, options);
-        } else if (c.operator === '<' || c.operator === '<=') {
-          lt = lowerLT(lt, c, options);
-        } else {
-          eqSet.add(c.semver);
-        }
+        if (c.operator === '>' || c.operator === '>=') gt = higherGT(gt, c, options);
+        else if (c.operator === '<' || c.operator === '<=') lt = lowerLT(lt, c, options);
+        else eqSet.add(c.semver);
       }
-      if (eqSet.size > 1) {
-        return null;
-      }
+      if (eqSet.size > 1) return null;
       let gtltComp;
       if (gt && lt) {
         gtltComp = compare(gt.semver, lt.semver, options);
-        if (gtltComp > 0) {
-          return null;
-        } else if (gtltComp === 0 && (gt.operator !== '>=' || lt.operator !== '<=')) {
-          return null;
-        }
+        if (gtltComp > 0) return null;
+        else if (gtltComp === 0 && (gt.operator !== '>=' || lt.operator !== '<=')) return null;
       }
       for (const eq of eqSet) {
-        if (gt && !satisfies(eq, String(gt), options)) {
-          return null;
-        }
-        if (lt && !satisfies(eq, String(lt), options)) {
-          return null;
-        }
+        if (gt && !satisfies(eq, String(gt), options)) return null;
+        if (lt && !satisfies(eq, String(lt), options)) return null;
         for (const c of dom) {
-          if (!satisfies(eq, String(c), options)) {
-            return false;
-          }
+          if (!satisfies(eq, String(c), options)) return false;
         }
         return true;
       }
@@ -19513,12 +20189,9 @@ var require_subset = __commonJS({
           }
           if (c.operator === '>' || c.operator === '>=') {
             higher = higherGT(gt, c, options);
-            if (higher === c && higher !== gt) {
-              return false;
-            }
-          } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options)) {
+            if (higher === c && higher !== gt) return false;
+          } else if (gt.operator === '>=' && !satisfies(gt.semver, String(c), options))
             return false;
-          }
         }
         if (lt) {
           if (needDomLTPre) {
@@ -19534,39 +20207,24 @@ var require_subset = __commonJS({
           }
           if (c.operator === '<' || c.operator === '<=') {
             lower = lowerLT(lt, c, options);
-            if (lower === c && lower !== lt) {
-              return false;
-            }
-          } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options)) {
+            if (lower === c && lower !== lt) return false;
+          } else if (lt.operator === '<=' && !satisfies(lt.semver, String(c), options))
             return false;
-          }
         }
-        if (!c.operator && (lt || gt) && gtltComp !== 0) {
-          return false;
-        }
+        if (!c.operator && (lt || gt) && gtltComp !== 0) return false;
       }
-      if (gt && hasDomLT && !lt && gtltComp !== 0) {
-        return false;
-      }
-      if (lt && hasDomGT && !gt && gtltComp !== 0) {
-        return false;
-      }
-      if (needDomGTPre || needDomLTPre) {
-        return false;
-      }
+      if (gt && hasDomLT && !lt && gtltComp !== 0) return false;
+      if (lt && hasDomGT && !gt && gtltComp !== 0) return false;
+      if (needDomGTPre || needDomLTPre) return false;
       return true;
     };
     var higherGT = (a, b, options) => {
-      if (!a) {
-        return b;
-      }
+      if (!a) return b;
       const comp = compare(a.semver, b.semver, options);
       return comp > 0 ? a : comp < 0 ? b : b.operator === '>' && a.operator === '>=' ? b : a;
     };
     var lowerLT = (a, b, options) => {
-      if (!a) {
-        return b;
-      }
+      if (!a) return b;
       const comp = compare(a.semver, b.semver, options);
       return comp < 0 ? a : comp > 0 ? b : b.operator === '<' && a.operator === '<=' ? b : a;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@actions/core": "^1.10.0",
-        "@actions/github": "^5.1.1",
-        "semver": "^7.3.7"
+        "@actions/github": "^5.0.0",
+        "semver": "^7.3.5"
       },
       "devDependencies": {
-        "esbuild": "^0.12.29",
+        "esbuild": "^0.12.8",
         "husky": "^4.3.8",
         "install": "^0.13.0",
-        "prettier": "^2.7.1"
+        "prettier": "^2.3.0"
       }
     },
     "node_modules/@actions/core": {
@@ -29,18 +29,7 @@
         "uuid": "^8.3.2"
       }
     },
-    "node_modules/@actions/github": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
-      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
-      "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "@octokit/core": "^3.6.0",
-        "@octokit/plugin-paginate-rest": "^2.17.0",
-        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
-      }
-    },
-    "node_modules/@actions/http-client": {
+    "node_modules/@actions/core/node_modules/@actions/http-client": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
       "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
@@ -48,34 +37,53 @@
         "tunnel": "^0.0.6"
       }
     },
+    "node_modules/@actions/github": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+      "dependencies": {
+        "@actions/http-client": "^1.0.11",
+        "@octokit/core": "^3.4.0",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "dependencies": {
+        "tunnel": "0.0.6"
+      }
+    },
     "node_modules/@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.14.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -121,13 +129,13 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -146,21 +154,21 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "dependencies": {
         "@octokit/types": "^6.0.3"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.3",
+        "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.0.5",
         "@octokit/types": "^6.0.3",
         "before-after-hook": "^2.2.0",
@@ -188,27 +196,27 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
+      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
+      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
       "dependencies": {
-        "@octokit/types": "^6.40.0"
+        "@octokit/types": "^6.26.0"
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.0.tgz",
+      "integrity": "sha512-HiUZliq5wNg15cevJlTo9zDnPXAD0BMRhLxbRNPnq9J3HELKesDTOiou56ax2jC/rECUkK/uJTugrizYKSo/jg==",
       "dependencies": {
-        "@octokit/types": "^6.39.0",
+        "@octokit/types": "^6.27.0",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -216,15 +224,15 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
+      "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
       "dependencies": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
@@ -239,11 +247,11 @@
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
+      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
       "dependencies": {
-        "@octokit/openapi-types": "^12.11.0"
+        "@octokit/openapi-types": "^10.1.0"
       }
     },
     "node_modules/@types/parse-json": {
@@ -358,9 +366,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.12.29",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
       "dev": true,
       "hasInstallScript": true,
       "bin": {
@@ -370,7 +378,7 @@
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true,
       "engines": {
         "node": ">=0.8.0"
@@ -474,7 +482,7 @@
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "node_modules/is-plain-object": {
@@ -498,9 +506,9 @@
       "dev": true
     },
     "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "node_modules/locate-path": {
@@ -551,7 +559,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
       }
@@ -665,18 +673,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
         "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/resolve-from": {
@@ -689,9 +694,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -705,7 +710,7 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "node_modules/semver-regex": {
@@ -744,7 +749,7 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -770,30 +775,27 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "dev": true
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "node_modules/yallist": {
       "version": "4.0.0",
@@ -830,49 +832,59 @@
       "requires": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@actions/http-client": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+          "requires": {
+            "tunnel": "^0.0.6"
+          }
+        }
       }
     },
     "@actions/github": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
-      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
+      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
       "requires": {
-        "@actions/http-client": "^2.0.1",
-        "@octokit/core": "^3.6.0",
-        "@octokit/plugin-paginate-rest": "^2.17.0",
-        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+        "@actions/http-client": "^1.0.11",
+        "@octokit/core": "^3.4.0",
+        "@octokit/plugin-paginate-rest": "^2.13.3",
+        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
       }
     },
     "@actions/http-client": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
+      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
       "requires": {
-        "tunnel": "^0.0.6"
+        "tunnel": "0.0.6"
       }
     },
     "@babel/code-frame": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.18.6"
+        "@babel/highlight": "^7.14.5"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "version": "7.14.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.14.5",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -909,13 +921,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
           "dev": true
         },
         "supports-color": {
@@ -930,21 +942,21 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
-      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
+      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
       "requires": {
         "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
+      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.3",
+        "@octokit/request": "^5.6.0",
         "@octokit/request-error": "^2.0.5",
         "@octokit/types": "^6.0.3",
         "before-after-hook": "^2.2.0",
@@ -972,37 +984,37 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "12.11.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
-      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
+      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.21.3",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
-      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
+      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
       "requires": {
-        "@octokit/types": "^6.40.0"
+        "@octokit/types": "^6.26.0"
       }
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.16.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
-      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.0.tgz",
+      "integrity": "sha512-HiUZliq5wNg15cevJlTo9zDnPXAD0BMRhLxbRNPnq9J3HELKesDTOiou56ax2jC/rECUkK/uJTugrizYKSo/jg==",
       "requires": {
-        "@octokit/types": "^6.39.0",
+        "@octokit/types": "^6.27.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
-      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
+      "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.6.1",
         "universal-user-agent": "^6.0.0"
       }
     },
@@ -1017,11 +1029,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.41.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
-      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
+      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
       "requires": {
-        "@octokit/openapi-types": "^12.11.0"
+        "@octokit/openapi-types": "^10.1.0"
       }
     },
     "@types/parse-json": {
@@ -1115,15 +1127,15 @@
       }
     },
     "esbuild": {
-      "version": "0.12.29",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
-      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
+      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "find-up": {
@@ -1188,7 +1200,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
     "is-plain-object": {
@@ -1209,9 +1221,9 @@
       "dev": true
     },
     "lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
       "dev": true
     },
     "locate-path": {
@@ -1242,7 +1254,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
         "wrappy": "1"
       }
@@ -1323,9 +1335,9 @@
       }
     },
     "prettier": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
-      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
       "dev": true
     },
     "resolve-from": {
@@ -1335,9 +1347,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -1345,7 +1357,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
       "dev": true
     },
     "semver-regex": {
@@ -1372,7 +1384,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
     "tunnel": {
       "version": "0.0.6",
@@ -1392,27 +1404,27 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "which-pm-runs": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,69 +1,878 @@
 {
   "name": "git-version-lite",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "@actions/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-5ad+U2YGrmmiw6du20AQW5XuWo7UKN2052FjSV7MX+Wfjf8sCqcsZe62NfgHys4QI4/Y+vQvLKYL8jWtA1ZBTA==",
-      "requires": {
+  "packages": {
+    "": {
+      "name": "git-version-lite",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@actions/core": "^1.10.0",
+        "@actions/github": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "devDependencies": {
+        "esbuild": "^0.12.29",
+        "husky": "^4.3.8",
+        "install": "^0.13.0",
+        "prettier": "^2.7.1"
+      }
+    },
+    "node_modules/@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
+      "dependencies": {
         "@actions/http-client": "^2.0.1",
         "uuid": "^8.3.2"
-      },
+      }
+    },
+    "node_modules/@actions/github": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
       "dependencies": {
-        "@actions/http-client": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
-          "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
-          "requires": {
-            "tunnel": "^0.0.6"
-          }
+        "@actions/http-client": "^2.0.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
+      }
+    },
+    "node_modules/@actions/http-client": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
+      "dependencies": {
+        "tunnel": "^0.0.6"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
+      "dependencies": {
+        "@octokit/auth-token": "^2.4.4",
+        "@octokit/graphql": "^4.5.8",
+        "@octokit/request": "^5.6.3",
+        "@octokit/request-error": "^2.0.5",
+        "@octokit/types": "^6.0.3",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.12.tgz",
+      "integrity": "sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "is-plain-object": "^5.0.0",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-4.8.0.tgz",
+      "integrity": "sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==",
+      "dependencies": {
+        "@octokit/request": "^5.6.0",
+        "@octokit/types": "^6.0.3",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
+      "dependencies": {
+        "@octokit/types": "^6.40.0"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=2"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
+      "dependencies": {
+        "@octokit/types": "^6.39.0",
+        "deprecation": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=3"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
+      "dependencies": {
+        "@octokit/endpoint": "^6.0.1",
+        "@octokit/request-error": "^2.1.0",
+        "@octokit/types": "^6.16.1",
+        "is-plain-object": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "universal-user-agent": "^6.0.0"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.1.0.tgz",
+      "integrity": "sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==",
+      "dependencies": {
+        "@octokit/types": "^6.0.3",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^12.11.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
+      "dev": true
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+      "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
+      "dev": true
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.12.29",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-versions": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz",
+      "integrity": "sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==",
+      "dev": true,
+      "dependencies": {
+        "semver-regex": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/husky": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-4.3.8.tgz",
+      "integrity": "sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "ci-info": "^2.0.0",
+        "compare-versions": "^3.6.0",
+        "cosmiconfig": "^7.0.0",
+        "find-versions": "^4.0.0",
+        "opencollective-postinstall": "^2.0.2",
+        "pkg-dir": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "slash": "^3.0.0",
+        "which-pm-runs": "^1.0.0"
+      },
+      "bin": {
+        "husky-run": "bin/run.js",
+        "husky-upgrade": "lib/upgrader/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/husky"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
         }
       }
     },
-    "@actions/github": {
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/opencollective-postinstall": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
+      "dev": true,
+      "bin": {
+        "opencollective-postinstall": "index.js"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.0.0.tgz",
-      "integrity": "sha512-QvE9eAAfEsS+yOOk0cylLBIO/d6WyWIOvsxxzdrPFaud39G6BOkUwScXZn1iBzQzHyu9SBkkLSWlohDWdsasAQ==",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dev": true,
+      "dependencies": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true
+    },
+    "node_modules/semver-regex": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz",
+      "integrity": "sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+      "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-pm-runs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  },
+  "dependencies": {
+    "@actions/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
-        "@actions/http-client": "^1.0.11",
-        "@octokit/core": "^3.4.0",
-        "@octokit/plugin-paginate-rest": "^2.13.3",
-        "@octokit/plugin-rest-endpoint-methods": "^5.1.1"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
+      }
+    },
+    "@actions/github": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+      "integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
+      "requires": {
+        "@actions/http-client": "^2.0.1",
+        "@octokit/core": "^3.6.0",
+        "@octokit/plugin-paginate-rest": "^2.17.0",
+        "@octokit/plugin-rest-endpoint-methods": "^5.13.0"
       }
     },
     "@actions/http-client": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.11.tgz",
-      "integrity": "sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.0.1.tgz",
+      "integrity": "sha512-PIXiMVtz6VvyaRsGY268qvj57hXQEpsYogYOu2nrQhlf+XCGmZstmuZBbAybUl1nQGnvS1k1eEsQ69ZoD7xlSw==",
       "requires": {
-        "tunnel": "0.0.6"
+        "tunnel": "^0.0.6"
       }
     },
     "@babel/code-frame": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-      "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.14.5"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.14.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-      "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "dev": true
     },
     "@babel/highlight": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-      "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.5",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -100,13 +909,13 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
           "dev": true
         },
         "has-flag": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
           "dev": true
         },
         "supports-color": {
@@ -121,21 +930,21 @@
       }
     },
     "@octokit/auth-token": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.4.5.tgz",
-      "integrity": "sha512-BpGYsPgJt05M7/L/5FoE1PiAbdxXFZkX/3kDYcsvd1v6UhlnE5e96dTDr0ezX/EFwciQxf3cNV0loipsURU+WA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-2.5.0.tgz",
+      "integrity": "sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==",
       "requires": {
         "@octokit/types": "^6.0.3"
       }
     },
     "@octokit/core": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.5.1.tgz",
-      "integrity": "sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
+      "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "requires": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
-        "@octokit/request": "^5.6.0",
+        "@octokit/request": "^5.6.3",
         "@octokit/request-error": "^2.0.5",
         "@octokit/types": "^6.0.3",
         "before-after-hook": "^2.2.0",
@@ -163,37 +972,37 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-10.1.1.tgz",
-      "integrity": "sha512-ygp/6r25Ezb1CJuVMnFfOsScEtPF0zosdTJDZ7mZ+I8IULl7DP1BS5ZvPRwglcarGPXOvS5sHdR0bjnVDDfQdQ=="
+      "version": "12.11.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-12.11.0.tgz",
+      "integrity": "sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ=="
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.16.0.tgz",
-      "integrity": "sha512-8YYzALPMvEZ35kgy5pdYvQ22Roz+BIuEaedO575GwE2vb/ACDqQn0xQrTJR4tnZCJn7pi8+AWPVjrFDaERIyXQ==",
+      "version": "2.21.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.21.3.tgz",
+      "integrity": "sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==",
       "requires": {
-        "@octokit/types": "^6.26.0"
+        "@octokit/types": "^6.40.0"
       }
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.10.0.tgz",
-      "integrity": "sha512-HiUZliq5wNg15cevJlTo9zDnPXAD0BMRhLxbRNPnq9J3HELKesDTOiou56ax2jC/rECUkK/uJTugrizYKSo/jg==",
+      "version": "5.16.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.2.tgz",
+      "integrity": "sha512-8QFz29Fg5jDuTPXVtey05BLm7OB+M8fnvE64RNegzX7U+5NUXcOcnpTIK0YfSHBg8gYd0oxIq3IZTe9SfPZiRw==",
       "requires": {
-        "@octokit/types": "^6.27.0",
+        "@octokit/types": "^6.39.0",
         "deprecation": "^2.3.1"
       }
     },
     "@octokit/request": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.1.tgz",
-      "integrity": "sha512-Ls2cfs1OfXaOKzkcxnqw5MR6drMA/zWX/LIS/p8Yjdz7QKTPQLMsB3R+OvoxE6XnXeXEE2X7xe4G4l4X0gRiKQ==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.6.3.tgz",
+      "integrity": "sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==",
       "requires": {
         "@octokit/endpoint": "^6.0.1",
         "@octokit/request-error": "^2.1.0",
         "@octokit/types": "^6.16.1",
         "is-plain-object": "^5.0.0",
-        "node-fetch": "^2.6.1",
+        "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
       }
     },
@@ -208,11 +1017,11 @@
       }
     },
     "@octokit/types": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.27.0.tgz",
-      "integrity": "sha512-ha27f8DToxXBPEJdzHCCuqpw7AgKfjhWGdNf3yIlBAhAsaexBXTfWw36zNSsncALXGvJq4EjLy1p3Wz45Aqb4A==",
+      "version": "6.41.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.41.0.tgz",
+      "integrity": "sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==",
       "requires": {
-        "@octokit/openapi-types": "^10.1.0"
+        "@octokit/openapi-types": "^12.11.0"
       }
     },
     "@types/parse-json": {
@@ -306,15 +1115,15 @@
       }
     },
     "esbuild": {
-      "version": "0.12.25",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.25.tgz",
-      "integrity": "sha512-woie0PosbRSoN8gQytrdCzUbS2ByKgO8nD1xCZkEup3D9q92miCze4PqEI9TZDYAuwn6CruEnQpJxgTRWdooAg==",
+      "version": "0.12.29",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.29.tgz",
+      "integrity": "sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true
     },
     "find-up": {
@@ -379,7 +1188,7 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
     },
     "is-plain-object": {
@@ -400,9 +1209,9 @@
       "dev": true
     },
     "lines-and-columns": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
     "locate-path": {
@@ -433,7 +1242,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -514,9 +1323,9 @@
       }
     },
     "prettier": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
-      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
       "dev": true
     },
     "resolve-from": {
@@ -526,9 +1335,9 @@
       "dev": true
     },
     "semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -536,7 +1345,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
     },
     "semver-regex": {
@@ -563,7 +1372,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tunnel": {
       "version": "0.0.6",
@@ -583,27 +1392,27 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
     "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "yallist": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -18,14 +18,14 @@
   "author": "wtw",
   "license": "ISC",
   "dependencies": {
-    "@actions/core": "^1.9.1",
-    "@actions/github": "^5.0.0",
-    "semver": "^7.3.5"
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^5.1.1",
+    "semver": "^7.3.7"
   },
   "devDependencies": {
-    "esbuild": "^0.12.8",
+    "esbuild": "^0.12.29",
     "husky": "^4.3.8",
     "install": "^0.13.0",
-    "prettier": "^2.3.0"
+    "prettier": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "license": "ISC",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/github": "^5.1.1",
-    "semver": "^7.3.7"
+    "@actions/github": "^5.0.0",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
-    "esbuild": "^0.12.29",
+    "esbuild": "^0.12.8",
     "husky": "^4.3.8",
     "install": "^0.13.0",
-    "prettier": "^2.7.1"
+    "prettier": "^2.3.0"
   }
 }


### PR DESCRIPTION
# Summary of PR changes

- Only include certain files when considering when to increment the tag.
- Remove the restriction on the build workflow, so we always get a status check
- Update actions to their latest tags
- This action already had the node version updated so it will only have a patch update
- Update actions/core to v1.10.0 to handle [untrusted logged data](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## PR Requirements
- [x] For JavaScript actions, the action has been recompiled.  
  - See the *Recompiling* section of the repository's README.md for more details.
  - This does not apply to Composite Run Steps actions unless a package.json is present and contains a build script.
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
