### PR TITLE
TW-64306: Output prior release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Commit unstaged readme/recompile changes if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'
+        id: commit-changes
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             echo "There are changes to commit"
@@ -66,3 +67,10 @@ jobs:
           else
             echo "There were no changes to commit"
           fi
+
+      - name: Upload dist folder as artifact on commit failure
+        if: failure() && steps.commit-changes.outcome == 'failure'
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,6 @@ jobs:
 
       - name: Commit unstaged readme/recompile changes if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'
-        id: commit-changes
         run: |
           if [[ "$(git status --porcelain)" != "" ]]; then
             echo "There are changes to commit"
@@ -67,10 +66,3 @@ jobs:
           else
             echo "There were no changes to commit"
           fi
-
-      - name: Upload dist folder as artifact on commit failure
-        if: failure() && steps.commit-changes.outcome == 'failure'
-        uses: actions/upload-artifact@v3
-        with:
-          name: dist
-          path: ./dist

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Each of the outputs are available as environment variables and as action outputs
 | `NEXT_MAJOR_VERSION`           | The next `major` version                                    |
 | `NEXT_MAJOR_VERSION_NO_PREFIX` | The next `major` version without the tag prefix             |
 | `NEXT_VERSION_SHA`             | The SHA of the next version as an environment variable      |
+| `PRIOR_VERSION`                | The previous `major.minor.patch` version                   |
 
 ## Usage Examples
 
@@ -101,7 +102,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2.2.0
+        uses: im-open/git-version-lite@v2.3.0
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/dist/index.js
+++ b/dist/index.js
@@ -19662,7 +19662,7 @@ Prior release version: ${priorReleaseVersion}`);
       let nextReleaseVersion3 = `${tagPrefix2}${semver.inc(priorReleaseVersion, releaseType)}`;
       core2.info(`Tag Prefix: '${tagPrefix2}'`);
       core2.info(`Next Release Version: ${nextReleaseVersion3}`);
-      return nextReleaseVersion3;
+      return [nextReleaseVersion3, priorReleaseVersion];
     }
     function nextPrereleaseVersion2(
       label,
@@ -19698,7 +19698,7 @@ Prior release version: ${priorReleaseVersion}`);
       core2.info(`Tag Prefix: '${tagPrefix2}'`);
       core2.info(`Cleaned Branch Name: '${label}'`);
       core2.info(`Next Pre-release Version: ${prereleaseVersion}`);
-      return prereleaseVersion;
+      return [prereleaseVersion, priorReleaseVersion];
     }
     module2.exports = {
       nextReleaseVersion: nextReleaseVersion2,
@@ -19748,12 +19748,12 @@ async function run() {
     if (tagPrefix.toLowerCase() == 'none') {
       tagPrefix = '';
     }
-    let versionToBuild;
+    let versionToBuild, priorReleaseVersion;
     if (calculatePrereleaseVersion) {
       const branchName = core.getInput('branch-name', requiredArgOptions);
       core.info(`Calculating a pre-release version for ${branchName}...`);
       const prereleaseLabel = branchName.replace('refs/heads/', '').replace(/[^a-zA-Z0-9-]/g, '-');
-      versionToBuild = nextPrereleaseVersion(
+      [versionToBuild, priorReleaseVersion] = nextPrereleaseVersion(
         prereleaseLabel,
         defaultReleaseType,
         tagPrefix,
@@ -19761,7 +19761,11 @@ async function run() {
       );
     } else {
       core.info(`Calculating a release version...`);
-      versionToBuild = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
+      [versionToBuild, priorReleaseVersion] = nextReleaseVersion(
+        defaultReleaseType,
+        tagPrefix,
+        fallbackToNoPrefixSearch
+      );
     }
     const sha =
       github.context.eventName === 'pull_request'
@@ -19779,7 +19783,8 @@ async function run() {
       NEXT_MINOR_VERSION_NO_PREFIX: versionPartsNoPrefix.slice(0, 2).join('.'),
       NEXT_MAJOR_VERSION: versionParts[0],
       NEXT_MAJOR_VERSION_NO_PREFIX: versionPartsNoPrefix[0],
-      NEXT_VERSION_SHA: sha
+      NEXT_VERSION_SHA: sha,
+      PRIOR_VERSION: priorReleaseVersion
     };
     Object.entries(outputs)
       .filter(([, value]) => value)

--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,11 @@ async function run() {
       );
     } else {
       core.info(`Calculating a release version...`);
-      [versionToBuild, priorReleaseVersion] = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
+      [versionToBuild, priorReleaseVersion] = nextReleaseVersion(
+        defaultReleaseType,
+        tagPrefix,
+        fallbackToNoPrefixSearch
+      );
     }
 
     // TODO: generate the sha from head https://github.com/im-open/git-version-lite/issues/24
@@ -92,7 +96,8 @@ async function run() {
       NEXT_MAJOR_VERSION: versionParts[0],
       NEXT_MAJOR_VERSION_NO_PREFIX: versionPartsNoPrefix[0],
 
-      NEXT_VERSION_SHA: sha
+      NEXT_VERSION_SHA: sha,
+      PRIOR_VERSION: priorReleaseVersion
     };
 
     Object.entries(outputs)

--- a/src/main.js
+++ b/src/main.js
@@ -56,14 +56,14 @@ async function run() {
       tagPrefix = '';
     }
 
-    let versionToBuild;
+    let versionToBuild, priorReleaseVersion;
     if (calculatePrereleaseVersion) {
       const branchName = core.getInput('branch-name', requiredArgOptions);
       core.info(`Calculating a pre-release version for ${branchName}...`);
 
       //This regex will strip out anything that's not a-z, 0-9 or the - character
       const prereleaseLabel = branchName.replace('refs/heads/', '').replace(/[^a-zA-Z0-9-]/g, '-');
-      versionToBuild = nextPrereleaseVersion(
+      [versionToBuild, priorReleaseVersion] = nextPrereleaseVersion(
         prereleaseLabel,
         defaultReleaseType,
         tagPrefix,
@@ -71,11 +71,15 @@ async function run() {
       );
     } else {
       core.info(`Calculating a release version...`);
-      versionToBuild = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
+      [versionToBuild, priorReleaseVersion] = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
     }
 
     if (createRef) {
       await createRefOnGitHub(versionToBuild);
+    }
+
+    if (priorReleaseVersion) {
+      core.setOutput('PRIOR_VERSION', priorReleaseVersion);
     }
 
     core.setOutput('NEXT_VERSION', versionToBuild);

--- a/src/main.js
+++ b/src/main.js
@@ -97,7 +97,7 @@ async function run() {
       NEXT_MAJOR_VERSION_NO_PREFIX: versionPartsNoPrefix[0],
 
       NEXT_VERSION_SHA: sha,
-      PRIOR_VERSION: priorReleaseVersion
+      PRIOR_RELEASE_VERSION: priorReleaseVersion
     };
 
     Object.entries(outputs)

--- a/src/version.js
+++ b/src/version.js
@@ -118,7 +118,9 @@ function dateToPreReleaseComponent(input) {
 /**
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {string} a SemVer release version based on the Git history since the last tagged release
+ * @typedef {string} NextReleaseVersion
+ * @typedef {string} PriorReleaseVersion
+ * @returns {[NextReleaseVersion, PriorReleaseVersion]} a SemVer release version based on the Git history since the last tagged release
  */
 function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
@@ -147,14 +149,16 @@ function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSea
   core.info(`Tag Prefix: '${tagPrefix}'`);
   core.info(`Next Release Version: ${nextReleaseVersion}`);
 
-  return nextReleaseVersion;
+  return [nextReleaseVersion, priorReleaseVersion];
 }
 
 /**
  * @param label {string} The pre-release label
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {string} a SemVer pre-release version based on the Git history since the last tagged release
+ * @typedef {string} PreReleaseVersion
+ * @typedef {string} PriorReleaseVersion
+ * @returns {[PreReleaseVersion, PriorReleaseVersion]} a SemVer pre-release version based on the Git history since the last tagged release
  */
 function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
@@ -187,7 +191,7 @@ function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToN
   core.info(`Cleaned Branch Name: '${label}'`);
   core.info(`Next Pre-release Version: ${prereleaseVersion}`);
 
-  return prereleaseVersion;
+  return [prereleaseVersion, priorReleaseVersion];
 }
 
 module.exports = {


### PR DESCRIPTION
https://jira.extendhealth.com/browse/TW-64306

# Summary of PR changes
Output prior version.

When pushing PR comments with the next version, in some cases it is helpful to update said comments with current release when a major or minor bump is not generated.  My team is using this in various scenarios and would rather not have to compute the previous version ourselves.  Since this action already gets the previous version, it seemed easy enough to include it as an output.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
