### PR TITLE
TW-64305: Create Major version tag on merge using GIT

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get the next version for the readme if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'
         id: version
-        uses: im-open/git-version-lite@v2.1.2
+        uses: ./
 
       - name: Update readme with next version if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           file-to-update: './README.md'
           action-name:  ${{ github.repository }}
-          updated-version: ${{ steps.version.outputs.NEXT_VERSION }}
+          updated-version: ${{ steps.version.outputs.NEXT_MAJOR_VERSION }}
 
       - name: Commit unstaged readme/recompile changes if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           file-to-update: './README.md'
           action-name:  ${{ github.repository }}
-          updated-version: ${{ steps.version.outputs.NEXT_MAJOR_VERSION }}
+          updated-version: ${{ steps.version.outputs.NEXT_VERSION }}
 
       - name: Commit unstaged readme/recompile changes if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -45,6 +45,13 @@ jobs:
       - name: Increment the version
         uses: im-open/git-version-lite@main
         with:
-          create-ref: true
+          create-ref: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
+          
+      - name: Create Release and Major Tags
+        run: |
+          git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
+          git tag ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -51,6 +51,8 @@ jobs:
           
       - name: Create Release and Major Tags
         run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
           git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
           git push origin ${{ steps.version.outputs.NEXT_VERSION }}
           git tag ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -55,4 +55,5 @@ jobs:
           git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
           git push origin ${{ steps.version.outputs.NEXT_VERSION }}
           git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MINOR_VERSION }} ${{ github.sha }}
           git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -38,14 +38,13 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          persist-credentials: false
 
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
+        id: version
         uses: ./
         with:
-          create-ref: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
           
@@ -55,5 +54,5 @@ jobs:
           git config user.email github-actions@github.com
           git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
           git push origin ${{ steps.version.outputs.NEXT_VERSION }}
-          git tag ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
+          git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
           git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -49,7 +49,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
           
-      - name: Create Release and Major Tags
+      - name: Create Version and Major Tags
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -43,7 +43,7 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@main
+        uses: ./
         with:
           create-ref: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -53,7 +53,8 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
           git tag ${{ steps.version.outputs.NEXT_VERSION }} ${{ github.sha }}
-          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
           git tag -f ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} ${{ github.sha }}
           git tag -f ${{ steps.version.outputs.NEXT_MINOR_VERSION }} ${{ github.sha }}
+          git push origin ${{ steps.version.outputs.NEXT_VERSION }}
           git push origin ${{ steps.version.outputs.NEXT_MAJOR_VERSION }} -f
+          git push origin ${{ steps.version.outputs.NEXT_MINOR_VERSION }} -f

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2.2.1
+        uses: im-open/git-version-lite@v2
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2
+        uses: im-open/git-version-lite@v2.2.1
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
-        uses: im-open/git-version-lite@v2.2.0
+        uses: im-open/git-version-lite@v2
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ jobs:
           fetch-depth: 0                        # Includes all history for all branches and tags
 
       - id: get-version
+        # You may also reference just the major version.
         uses: im-open/git-version-lite@v2.2.1
         with:
           calculate-prerelease-version: true

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'git-version-lite'
+name: git-version-lite
 
-description: 'An action to calculate the next tag for the repository based on commit messages.'
+description: An action to calculate the next tag for the repository based on commit messages.
 
 inputs:
   calculate-prerelease-version:


### PR DESCRIPTION
[TW-64305](https://jira.extendhealth.com/browse/TW-64305)

# Summary of PR changes
Allow the creation of a major tag adjacent to the normal major + minor + patch release creation.

This allows downstream workflows to reference the major version instead of the specific minor + patch. Doing so will reduce dependabot alerts and unnecessary PRs to get the latest minor version.

This is similar to the same pattern used with GitHub Actions.
https://github.com/actions/toolkit/blob/main/docs/action-versioning.md#recommendations

As an example, release `v1.2.3` is created with an accompanying `v1` tag.  Downstream consumers of this repo can reference `v1` instead of `v1.2.3`.

## Gotchas
1. `persist-credentials: false` on the `actions/checkout` must be removed or you get this [error](https://github.com/bradyclifford/git-version-lite/actions/runs/4327307781/jobs/7555785531)
2. Workflow permissions must be set to "Read and write permissions"
3. When creating the major tag, `git -f` must be used to force the replacement or you will get this [error](https://github.com/bradyclifford/git-version-lite/actions/runs/4327319143/jobs/7555810533)

> 1 can be avoided if instead the Octokit create tag REST endpoint is used.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
