### PR TITLE
TW-64306: Output prior release

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each of the outputs are available as environment variables and as action outputs
 | `NEXT_MAJOR_VERSION_NO_PREFIX` | The next `major` version without the tag prefix             |
 | `NEXT_VERSION_SHA`             | The SHA of the next version as an environment variable      |
 | `PRIOR_VERSION`                | The previous `major.minor.patch` version                   |
-| `PRIOR_VERSION_NO_PREFIX`      | The previous `major.minor.patch` version wihtout the tag prefix |
+| `PRIOR_VERSION_NO_PREFIX`      | The previous `major.minor.patch` version without the tag prefix |
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
 
       - id: get-version
         # You may also reference just the major version.
-        uses: im-open/git-version-lite@v2.2.1
+        uses: im-open/git-version-lite@v2.3.0
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Each of the outputs are available as environment variables and as action outputs
 | `NEXT_MAJOR_VERSION`           | The next `major` version                                    |
 | `NEXT_MAJOR_VERSION_NO_PREFIX` | The next `major` version without the tag prefix             |
 | `NEXT_VERSION_SHA`             | The SHA of the next version as an environment variable      |
+| `PRIOR_VERSION`                | The previous `major.minor.patch` version                   |
+| `PRIOR_VERSION_NO_PREFIX`      | The previous `major.minor.patch` version wihtout the tag prefix |
 
 ## Usage Examples
 

--- a/action.yml
+++ b/action.yml
@@ -7,34 +7,35 @@ inputs:
     description: 'Flag indicating whether to calculate a pre-release version rather than a release version.  Accepts: true|false.'
     required: true
     default: 'false'
+
   branch-name:
     description: 'The name of the branch the tag is being generated for. Required when calculating the pre-release version.'
     required: false
+
   tag-prefix:
     description: 'By default the action strips the prefixes off, but any value provided here will be prepended to the next calculated version.'
     required: true
     default: 'v'
+
   fallback-to-no-prefix-search:
     description: 'Flag indicating whether it should fallback to a prefix-less search if no tags are found with the current prefix.  Helpful when starting to use prefixes with tags.  Accepted values: true|false.'
     required: true
     default: 'true'
+
   default-release-type:
     description: 'The default release type that should be used when no tags are detected.  Defaults to major.  Accepted values: major|minor|patch'
     required: true
     default: 'major'
+
+  # Deprecated input. Instead create a release with the im-open/create-release action
   create-ref:
     description: 'Flag indicating whether the action should create a ref (a release and tag) on the repository.  Accepted values: true|false'
     required: true
     default: 'false'
+    
   github-token:
     description: Token with permissions to push a ref to the repository
     required: false
-
-outputs:
-  NEXT_VERSION:
-    description: 'The calculated next version'
-  NEXT_VERSION_NO_PREFIX:
-    description: 'The calculated next version without the tag prefix.'
 
 runs:
   using: 'node16'

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,34 @@ inputs:
   github-token:
     description: Token with permissions to push a ref to the repository
     required: false
+    
+outputs:
+  NEXT_VERSION:
+    description: 'The calculated next version.'
+    
+  NEXT_VERSION_NO_PREFIX:
+    description: 'The calculated next version without the tag prefix.'
+    
+  NEXT_MINOR_VERSION:
+    description: 'The next major.minor version.'
+    
+  NEXT_MINOR_VERSION_NO_PREFIX:
+    description: 'The next major.minor version without the tag prefix.'
+    
+  NEXT_MAJOR_VERSION:
+    description: 'The next major version.'
+    
+  NEXT_MAJOR_VERSION_NO_PREFIX:
+    description: 'The next major version without the tag prefix.'
+    
+  NEXT_VERSION_SHA:
+    description: 'The SHA of the next version as an environment variable.'
+    
+  PRIOR_VERSION:
+    description: 'The previous major.minor.patch version.'
+    
+  PRIOR_VERSION_NO_PREFIX:
+    description: 'The previous major.minor.patch version without the tag prefix.'
 
 runs:
   using: 'node16'

--- a/dist/index.js
+++ b/dist/index.js
@@ -19777,7 +19777,7 @@ async function run() {
     const outputVersionEntries = Object.entries({
       NEXT_VERSION: nextVersion.toString(),
       NEXT_MINOR_VERSION: `${nextVersion.major}.${nextVersion.minor}`,
-      NEXT_MAJOR_VERSION: nextVersion.minor,
+      NEXT_MAJOR_VERSION: nextVersion.major,
       PRIOR_VERSION: priorVersion.toString()
     });
     [

--- a/dist/index.js
+++ b/dist/index.js
@@ -19549,6 +19549,7 @@ var require_version2 = __commonJS({
     var git = require_git_commands();
     var core2 = require_core();
     var semver = require_semver2();
+    var SemVer = require_semver();
     var commitPatterns = {
       major: [/\+semver:\s*(breaking|major)/i, /BREAKING CHANGES?:?/],
       minor: [
@@ -19659,10 +19660,10 @@ Prior release version default: ${priorReleaseVersion}`);
 Prior release version: ${priorReleaseVersion}`);
         core2.info(`Release Type: ${releaseType}`);
       }
-      let nextReleaseVersion3 = `${tagPrefix2}${semver.inc(priorReleaseVersion, releaseType)}`;
-      core2.info(`Tag Prefix: '${tagPrefix2}'`);
-      core2.info(`Next Release Version: ${nextReleaseVersion3}`);
-      return nextReleaseVersion3;
+      return {
+        priorVersion: new SemVer(priorReleaseVersion),
+        nextVersion: new SemVer(semver.inc(priorReleaseVersion, releaseType))
+      };
     }
     function nextPrereleaseVersion2(
       label,
@@ -19694,11 +19695,12 @@ Prior release version: ${priorReleaseVersion}`);
         core2.info(`Release Type: ${releaseType}`);
       }
       let nextReleaseVersion3 = semver.inc(priorReleaseVersion, releaseType);
-      let prereleaseVersion = `${tagPrefix2}${nextReleaseVersion3}-${label}.${formattedDate}`;
-      core2.info(`Tag Prefix: '${tagPrefix2}'`);
+      let prereleaseVersion = `${nextReleaseVersion3}-${label}.${formattedDate}`;
       core2.info(`Cleaned Branch Name: '${label}'`);
-      core2.info(`Next Pre-release Version: ${prereleaseVersion}`);
-      return prereleaseVersion;
+      return {
+        priorVersion: new SemVer(priorReleaseVersion),
+        nextVersion: new SemVer(prereleaseVersion)
+      };
     }
     module2.exports = {
       nextReleaseVersion: nextReleaseVersion2,
@@ -19748,6 +19750,7 @@ async function run() {
     if (tagPrefix.toLowerCase() == 'none') {
       tagPrefix = '';
     }
+    core.info(`Tag Prefix: '${tagPrefix}'`);
     let versionToBuild;
     if (calculatePrereleaseVersion) {
       const branchName = core.getInput('branch-name', requiredArgOptions);
@@ -19770,24 +19773,22 @@ async function run() {
     if (createRef) {
       await createRefOnGitHub(versionToBuild, sha);
     }
-    const versionParts = versionToBuild?.split('.') ?? [];
-    const versionPartsNoPrefix = versionToBuild?.substring(tagPrefix.length).split('.') ?? [];
-    const outputs = {
-      NEXT_VERSION: versionToBuild,
-      NEXT_VERSION_NO_PREFIX: versionPartsNoPrefix?.join('.'),
-      NEXT_MINOR_VERSION: versionParts.slice(0, 2).join('.'),
-      NEXT_MINOR_VERSION_NO_PREFIX: versionPartsNoPrefix.slice(0, 2).join('.'),
-      NEXT_MAJOR_VERSION: versionParts[0],
-      NEXT_MAJOR_VERSION_NO_PREFIX: versionPartsNoPrefix[0],
-      NEXT_VERSION_SHA: sha
-    };
-    Object.entries(outputs)
-      .filter(([, value]) => value)
-      .forEach(pair => {
-        core.setOutput(...pair);
-        core.exportVariable(...pair);
-        core.info(...pair);
-      });
+    const { nextVersion, priorVersion } = versionToBuild;
+    const outputVersionEntries = Object.entries({
+      NEXT_VERSION: nextVersion.toString(),
+      NEXT_MINOR_VERSION: `${nextVersion.major}.${nextVersion.minor}`,
+      NEXT_MAJOR_VERSION: nextVersion.minor,
+      PRIOR_VERSION: priorVersion.toString()
+    });
+    [
+      ['NEXT_VERSION_SHA', sha],
+      ...outputVersionEntries.map(([name, value]) => [name, `${tagPrefix}${value}`]),
+      ...outputVersionEntries.map(([name, value]) => [`${name}_NO_PREFIX`, value])
+    ].forEach(entry => {
+      core.setOutput(...entry);
+      core.exportVariable(...entry);
+      console.info(...entry);
+    });
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';
     core.setFailed(

--- a/src/main.js
+++ b/src/main.js
@@ -65,12 +65,9 @@ async function run() {
         tagPrefix,
         fallbackToNoPrefixSearch
       );
-
-      core.info(`Next Pre-release Version: ${prereleaseVersion}`);
     } else {
       core.info(`Calculating a release version...`);
       versionToBuild = nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch);
-      core.info(`Next Release Version: ${tagPrefix}${versionToBuild.nextVersion}`);
     }
 
     // TODO: generate the sha from head https://github.com/im-open/git-version-lite/issues/24
@@ -92,19 +89,19 @@ async function run() {
       PRIOR_VERSION: priorVersion.toString()
     });
 
-    const outputsVersionEntriesWithoutPrefix = outputVersionEntries
-      .map(([name, value]) => [`${name}_NO_PREFIX`, `${tagPrefix}${value}`]);
-
     [
-      ...outputVersionEntries,
-      ...outputsVersionEntriesWithoutPrefix,
       ['NEXT_VERSION_SHA', sha],
+
+      ...outputVersionEntries
+        .map(([name, value]) => [name, `${tagPrefix}${value}`]),
+
+      ...outputVersionEntries
+        .map(([name, value]) => [`${name}_NO_PREFIX`, value])
     ]
-      .filter(([, value]) => value)
-      .forEach(pair => {
-        core.setOutput(...pair);
-        core.exportVariable(...pair);
-        core.info(...pair);
+      .forEach(entry => {
+        core.setOutput(...entry);
+        core.exportVariable(...entry);
+        console.info(...entry);
       });
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';

--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ async function run() {
     const outputVersionEntries = Object.entries({
       NEXT_VERSION: nextVersion.toString(),
       NEXT_MINOR_VERSION: `${nextVersion.major}.${nextVersion.minor}`,
-      NEXT_MAJOR_VERSION: nextVersion.minor,
+      NEXT_MAJOR_VERSION: nextVersion.major,
       PRIOR_VERSION: priorVersion.toString()
     });
 

--- a/src/main.js
+++ b/src/main.js
@@ -92,17 +92,14 @@ async function run() {
     [
       ['NEXT_VERSION_SHA', sha],
 
-      ...outputVersionEntries
-        .map(([name, value]) => [name, `${tagPrefix}${value}`]),
+      ...outputVersionEntries.map(([name, value]) => [name, `${tagPrefix}${value}`]),
 
-      ...outputVersionEntries
-        .map(([name, value]) => [`${name}_NO_PREFIX`, value])
-    ]
-      .forEach(entry => {
-        core.setOutput(...entry);
-        core.exportVariable(...entry);
-        console.info(...entry);
-      });
+      ...outputVersionEntries.map(([name, value]) => [`${name}_NO_PREFIX`, value])
+    ].forEach(entry => {
+      core.setOutput(...entry);
+      core.exportVariable(...entry);
+      console.info(...entry);
+    });
   } catch (error) {
     const versionTxt = calculatePrereleaseVersion ? 'pre-release' : 'release';
     core.setFailed(

--- a/src/version.js
+++ b/src/version.js
@@ -126,7 +126,7 @@ function dateToPreReleaseComponent(input) {
 /**
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {ReleaseBucket} a SemVer based on the Git history since the last tagged release
+ * @returns {ReleaseBucket} a SemVer next and prior versions based on the Git history since the last tagged release
  */
 function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
@@ -161,7 +161,7 @@ function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSea
  * @param label {string} The pre-release label
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {ReleaseBucket} a SemVer pre-release version based on the Git history since the last tagged release
+ * @returns {ReleaseBucket} a pre-release next and prior versions based on the Git history since the last tagged release
  */
 function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;

--- a/src/version.js
+++ b/src/version.js
@@ -1,6 +1,7 @@
 const git = require('./git-commands.js');
 const core = require('@actions/core');
 const semver = require('semver');
+const SemVer = require('semver/classes/semver');
 
 // These commit message patterns are a combination of GitVersion's commit message conventions and
 // Angular's which seem to be widely immitated including in semantic-release.
@@ -116,9 +117,16 @@ function dateToPreReleaseComponent(input) {
 }
 
 /**
+ * @typedef {{
+ *  priorVersion: SemVer,
+ *  nextVersion: SemVer
+ * }} ReleaseBucket
+ */
+
+/**
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {string} a SemVer release version based on the Git history since the last tagged release
+ * @returns {ReleaseBucket} a SemVer based on the Git history since the last tagged release
  */
 function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
@@ -143,18 +151,17 @@ function nextReleaseVersion(defaultReleaseType, tagPrefix, fallbackToNoPrefixSea
     core.info(`Release Type: ${releaseType}`);
   }
 
-  let nextReleaseVersion = `${tagPrefix}${semver.inc(priorReleaseVersion, releaseType)}`;
-  core.info(`Tag Prefix: '${tagPrefix}'`);
-  core.info(`Next Release Version: ${nextReleaseVersion}`);
-
-  return nextReleaseVersion;
+  return {
+    priorVersion: new SemVer(priorReleaseVersion),
+    nextVersion: new SemVer(semver.inc(priorReleaseVersion, releaseType))
+  };
 }
 
 /**
  * @param label {string} The pre-release label
  * @param defaultReleaseType {string} The default release type to use if no tags are detected
  * @param tagPrefix {string} The value to pre-pend to the calculated release
- * @returns {string} a SemVer pre-release version based on the Git history since the last tagged release
+ * @returns {ReleaseBucket} a SemVer pre-release version based on the Git history since the last tagged release
  */
 function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToNoPrefixSearch) {
   let baseCommit;
@@ -182,12 +189,13 @@ function nextPrereleaseVersion(label, defaultReleaseType, tagPrefix, fallbackToN
     core.info(`Release Type: ${releaseType}`);
   }
   let nextReleaseVersion = semver.inc(priorReleaseVersion, releaseType);
-  let prereleaseVersion = `${tagPrefix}${nextReleaseVersion}-${label}.${formattedDate}`;
-  core.info(`Tag Prefix: '${tagPrefix}'`);
+  let prereleaseVersion = `${nextReleaseVersion}-${label}.${formattedDate}`;
   core.info(`Cleaned Branch Name: '${label}'`);
-  core.info(`Next Pre-release Version: ${prereleaseVersion}`);
 
-  return prereleaseVersion;
+  return {
+    priorVersion: new SemVer(priorReleaseVersion),
+    nextVersion: new SemVer(prereleaseVersion)
+  };
 }
 
 module.exports = {


### PR DESCRIPTION
https://jira.extendhealth.com/browse/TW-64306

# Summary of PR changes
Output prior version.

When pushing PR comments with the next version, in some cases it is helpful to update said comments with current release when a major or minor bump is not generated.  It is also helpful when adding the version to a `CHANGES.md`.  My team is using this in various scenarios and would rather not have to compute the previous version ourselves.  Since this action already gets the previous version, it seemed easy enough to include it as an output.

Expanded on the suggestion made by @mike-schenk on previous PR #30 
https://github.com/im-open/git-version-lite/pull/30/files#r1113592442

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
