### PR TITLE
Creating release issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
 
       - id: get-version
         # You may also reference just the major version.
-        uses: im-open/git-version-lite@v2.3.0
+        uses: im-open/git-version-lite@v2.3.1
         with:
           calculate-prerelease-version: true
           branch-name: ${{ github.head_ref }}       # github.head_ref works when the trigger is pull_request

--- a/dist/index.js
+++ b/dist/index.js
@@ -19770,10 +19770,10 @@ async function run() {
       github.context.eventName === 'pull_request'
         ? github.context.payload.pull_request.head.sha
         : github.context.sha;
-    if (createRef) {
-      await createRefOnGitHub(versionToBuild, sha);
-    }
     const { nextVersion, priorVersion } = versionToBuild;
+    if (createRef) {
+      await createRefOnGitHub(nextVersion.toString(), sha);
+    }
     const outputVersionEntries = Object.entries({
       NEXT_VERSION: nextVersion.toString(),
       NEXT_MINOR_VERSION: `${nextVersion.major}.${nextVersion.minor}`,

--- a/dist/index.js
+++ b/dist/index.js
@@ -19772,7 +19772,7 @@ async function run() {
         : github.context.sha;
     const { nextVersion, priorVersion } = versionToBuild;
     if (createRef) {
-      await createRefOnGitHub(nextVersion.toString(), sha);
+      await createRefOnGitHub(`${tagPrefix}${nextVersion.toString()}`, sha);
     }
     const outputVersionEntries = Object.entries({
       NEXT_VERSION: nextVersion.toString(),

--- a/src/main.js
+++ b/src/main.js
@@ -79,7 +79,7 @@ async function run() {
     const { nextVersion, priorVersion } = versionToBuild;
 
     if (createRef) {
-      await createRefOnGitHub(nextVersion.toString(), sha);
+      await createRefOnGitHub(`${tagPrefix}${nextVersion.toString()}`, sha);
     }
 
     const outputVersionEntries = Object.entries({

--- a/src/main.js
+++ b/src/main.js
@@ -75,7 +75,7 @@ async function run() {
       github.context.eventName === 'pull_request'
         ? github.context.payload.pull_request.head.sha
         : github.context.sha;
-        
+
     const { nextVersion, priorVersion } = versionToBuild;
 
     if (createRef) {

--- a/src/main.js
+++ b/src/main.js
@@ -75,12 +75,12 @@ async function run() {
       github.context.eventName === 'pull_request'
         ? github.context.payload.pull_request.head.sha
         : github.context.sha;
+        
+    const { nextVersion, priorVersion } = versionToBuild;
 
     if (createRef) {
-      await createRefOnGitHub(versionToBuild, sha);
+      await createRefOnGitHub(nextVersion.toString(), sha);
     }
-
-    const { nextVersion, priorVersion } = versionToBuild;
 
     const outputVersionEntries = Object.entries({
       NEXT_VERSION: nextVersion.toString(),
@@ -91,9 +91,7 @@ async function run() {
 
     [
       ['NEXT_VERSION_SHA', sha],
-
       ...outputVersionEntries.map(([name, value]) => [name, `${tagPrefix}${value}`]),
-
       ...outputVersionEntries.map(([name, value]) => [`${name}_NO_PREFIX`, value])
     ].forEach(entry => {
       core.setOutput(...entry);


### PR DESCRIPTION
# Summary of PR changes
When creating a release, the full semver object was being passed  and erroring out.  Need to explicitly call `toString()` on the semver object.

![image](https://user-images.githubusercontent.com/8923247/234948814-a14d39b9-6b4f-4e84-8bc5-339744887420.png)

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
